### PR TITLE
Avoid potential race condition between close/drain events when piping

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -50,7 +50,9 @@ class Stream extends EventEmitter implements ReadableStreamInterface, WritableSt
 
     public function resume()
     {
-        $this->loop->addReadStream($this->stream, array($this, 'handleData'));
+        if ($this->readable) {
+            $this->loop->addReadStream($this->stream, array($this, 'handleData'));
+        }
     }
 
     public function write($data)


### PR DESCRIPTION
When piping data, it is possible that a stream may emit the `drain` event after the `close` event. This causes the stream to be watched for readable data that will never arrive and the handler will never be removed - causing the process to run forever when there is technically nothing left to do.

I found I could demonstrate this problem about 1/10 runs of the reactphp/react `parallel-download` example.

This patch addresses the problem by refusing to `resume()` if the stream is not marked as readable.
