### PR TITLE
Handle websocket over nginx's proxy_pass

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -129,7 +129,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         // Here is the proposed fix
         
         // Drain everything that is current on the socket
-        
+        $additionalData = NULL;
         try{
             while(($additionalData = fread($stream, $this->bufferSize))) {
                 // Drain anything that is in the buffer before initializing other handlers


### PR DESCRIPTION
When used on nginx to proxy pass ratchet websocket over https and extending Ratchet as a client on RaPI
We found a weird issue where nginx will end each response with a EOF
So, if we do a fread then we will only get one communication message at a time
This caused a weird issue, where the message seemed to lag by one message
Here is the proposed fix
