### PR TITLE
Drain all the message available if any.

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -121,6 +121,10 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $data = fread($stream, $this->bufferSize);
 
         $this->emit('data', array($data, $this));
+        
+        while(is_resource($stream) && ($additionalData = fread($stream, $this->bufferSize))) {
+            $this->emit('data', array($additionalData, $this));
+        }
 
         if (!is_resource($stream) || feof($stream)) {
             $this->end();


### PR DESCRIPTION
We recently implemented ratchet websocket server on top of nginx using proxy_pass over https
The client was also written on PHp which was run on RaPI
The issue we found was that, nginx was sending an EOL with every response
There were certain cases when the socket response header and a WS message reached the client at the same time
concatenated, but the function will cause issue because it will stop when it reached EOL and then there will be a weird issue where the message seems to be off by 1 message.
