### PR TITLE
Changes to Buffer::write() behaviour

### DIFF
--- a/src/BufferedSink.php
+++ b/src/BufferedSink.php
@@ -4,6 +4,7 @@ namespace React\Stream;
 
 use React\Promise\Deferred;
 use React\Promise\PromisorInterface;
+use React\Promise\FulfilledPromise;
 
 class BufferedSink extends WritableStream implements PromisorInterface
 {
@@ -32,6 +33,7 @@ class BufferedSink extends WritableStream implements PromisorInterface
     {
         $this->buffer .= $data;
         $this->deferred->progress($data);
+        return new FulfilledPromise();
     }
 
     public function close()

--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -16,7 +16,7 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
         $this->writable = $writable;
 
         Util::forwardEvents($this->readable, $this, array('data', 'end', 'error', 'close'));
-        Util::forwardEvents($this->writable, $this, array('drain', 'error', 'close', 'pipe'));
+        Util::forwardEvents($this->writable, $this, array('drain', 'full', 'error', 'close', 'pipe'));
 
         $this->readable->on('close', array($this, 'close'));
         $this->writable->on('close', array($this, 'close'));

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -2,6 +2,8 @@
 
 namespace React\Stream;
 
+use React\Promise\FulfilledPromise;
+
 class ThroughStream extends CompositeStream
 {
     public function __construct()
@@ -20,6 +22,7 @@ class ThroughStream extends CompositeStream
     public function write($data)
     {
         $this->readable->emit('data', array($this->filter($data), $this));
+        return new FulfilledPromise();
     }
 
     public function end($data = null)

--- a/src/Util.php
+++ b/src/Util.php
@@ -2,6 +2,8 @@
 
 namespace React\Stream;
 
+use React\Promise;
+
 // TODO: move to a trait
 
 class Util
@@ -14,12 +16,12 @@ class Util
 
         $dest->emit('pipe', array($source));
 
-        $source->on('data', function ($data) use ($source, $dest) {
-            $feedMore = $dest->write($data);
+        $source->on('data', function ($data) use ($source, $dest, &$promises) {
+            $dest->write($data);
+        });
 
-            if (false === $feedMore) {
-                $source->pause();
-            }
+        $dest->on('full', function () use ($source) {
+            $source->pause();
         });
 
         $dest->on('drain', function () use ($source) {

--- a/src/WritableStream.php
+++ b/src/WritableStream.php
@@ -2,6 +2,7 @@
 
 namespace React\Stream;
 
+use React\Promise\FulfilledPromise;
 use Evenement\EventEmitter;
 
 class WritableStream extends EventEmitter implements WritableStreamInterface
@@ -10,6 +11,7 @@ class WritableStream extends EventEmitter implements WritableStreamInterface
 
     public function write($data)
     {
+        return new FulfilledPromise();
     }
 
     public function end($data = null)

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -119,7 +119,17 @@ class CompositeStreamTest extends TestCase
         $writable
             ->expects($this->once())
             ->method('write')
-            ->will($this->returnValue(false));
+            ->will($this->returnCallback(function() use ($writable) {
+                $writable->emit('full');
+            }));
+
+        $writable
+            ->expects($this->any())
+            ->method('on')
+            ->will($this->returnCallback(function($name, $callback) {
+                echo $name, "\n";
+            }));
+            
 
         $composite = new CompositeStream($readable, $writable);
 

--- a/tests/Stub/LimitedStreamStub.php
+++ b/tests/Stub/LimitedStreamStub.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace React\Tests\Stream\Stub;
+
+class LimitedStreamStub
+{
+
+    protected $canWrite;
+
+    public function stream_open($path)
+    {
+        $url = parse_url($path);
+        $this->canWrite = (int) $url['host'];
+        return true;
+    }
+
+    public function stream_write($data)
+    {
+        $written = min($this->canWrite, strlen($data));
+        $this->canWrite -= $written;
+
+        return $written;
+    }
+
+    public function stream_eof()
+    {
+        return false;
+    }
+}
+


### PR DESCRIPTION
The following is a proposal for a BC breaking change regarding the `WritableStreamInterface::write()` signature.

Currently the `WritableStreamInterface` does not hint on any return type. `WritableStream` is a `void`, `Stream` returns a `boolean` indicating whether the internal buffer is full (as described in the README).

This PR changes `Stream`, `WritableStream`, `CompositeStream` and `ThroughStream` so that their `write`-methods all return a `React\Promise\PromiseInterface`.  `Stream` (or rather `Buffer`) resolves this promise when `fwrite` accepted all bytes. The other implementations all return a `FulfilledPromise` (instead of being a `void`)

`Util::pipe()` embraces this change by triggering `pause()` on the readable stream, when it encounters the `full`-event instead of `write()` returning false. `CompositeStream` therefore also needs to forward the `full`-event from the writable stream to itself.

Tests have been amended/fixed to reflect the changed behavior.

TODO:
- Discuss whether this is a sensible change :smile:
- Better name for the `full` event? Maybe `buffer-full`? 
- Update the documentation
