### PR TITLE
[RFC] Remove "end" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ This component depends on `événement`, which is an implementation of the
 ### EventEmitter Events
 
 * `data`: Emitted whenever data was read from the source.
-* `end`: Emitted when the source has reached the `eof`.
 * `error`: Emitted when an error occurs.
-* `close`: Emitted when the connection is closed.
+* `close`: Emitted when the source has reached the `eof` or is closed.
 
 ### Methods
 

--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -15,7 +15,7 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
         $this->readable = $readable;
         $this->writable = $writable;
 
-        Util::forwardEvents($this->readable, $this, array('data', 'end', 'error', 'close'));
+        Util::forwardEvents($this->readable, $this, array('data', 'error', 'close'));
         Util::forwardEvents($this->writable, $this, array('drain', 'error', 'close', 'pipe'));
 
         $this->readable->on('close', array($this, 'close'));

--- a/src/ReadableStream.php
+++ b/src/ReadableStream.php
@@ -35,7 +35,6 @@ class ReadableStream extends EventEmitter implements ReadableStreamInterface
         }
 
         $this->closed = true;
-        $this->emit('end', array($this));
         $this->emit('close', array($this));
         $this->removeAllListeners();
     }

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -6,7 +6,6 @@ use Evenement\EventEmitterInterface;
 
 /**
  * @event data
- * @event end
  * @event error
  * @event close
  */

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -82,7 +82,6 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $this->readable = false;
         $this->writable = false;
 
-        $this->emit('end', array($this));
         $this->emit('close', array($this));
         $this->loop->removeStream($this->stream);
         $this->buffer->removeAllListeners();

--- a/src/Util.php
+++ b/src/Util.php
@@ -26,9 +26,9 @@ class Util
             $source->resume();
         });
 
-        $end = isset($options['end']) ? $options['end'] : true;
+        $end = isset($options['close']) ? $options['close'] : true;
         if ($end && $source !== $dest) {
-            $source->on('end', function () use ($dest) {
+            $source->on('close', function () use ($dest) {
                 $dest->end();
             });
         }

--- a/src/WritableStream.php
+++ b/src/WritableStream.php
@@ -33,7 +33,6 @@ class WritableStream extends EventEmitter implements WritableStreamInterface
         }
 
         $this->closed = true;
-        $this->emit('end', array($this));
         $this->emit('close', array($this));
         $this->removeAllListeners();
     }

--- a/tests/Stub/ReadableStreamStub.php
+++ b/tests/Stub/ReadableStreamStub.php
@@ -32,7 +32,7 @@ class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
     // trigger end event
     public function end()
     {
-        $this->emit('end', array());
+        $this->close();
     }
 
     public function pause()

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -21,7 +21,7 @@ class UtilTest extends TestCase
         $readable
             ->expects($this->at(1))
             ->method('on')
-            ->with('end', $this->isInstanceOf('Closure'));
+            ->with('close', $this->isInstanceOf('Closure'));
 
         $writable = $this->getMock('React\Stream\WritableStreamInterface');
         $writable
@@ -55,7 +55,7 @@ class UtilTest extends TestCase
             ->expects($this->never())
             ->method('end');
 
-        Util::pipe($readable, $writable, array('end' => false));
+        Util::pipe($readable, $writable, array('close' => false));
 
         $readable->end();
     }


### PR DESCRIPTION
This PR is a RFC – any input is welcome.

Whenever we reach EOF for a stream, we invoke the `end()` method. This will always emit an "end" and a "close" event.

This PR aims to serve as a discussion basis whether it actually makes sense to keep both.
