### PR TITLE
Fixed double-writes when write() is called during 'drain' event

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -111,11 +111,11 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         }
 
         $len = strlen($this->data);
+        $this->data = (string) substr($this->data, $sent);
+
         if ($len >= $this->softLimit && $len - $sent < $this->softLimit) {
             $this->emit('drain', [$this]);
         }
-
-        $this->data = (string) substr($this->data, $sent);
 
         if (0 === strlen($this->data)) {
             $this->loop->removeWriteStream($this->stream);


### PR DESCRIPTION
When `write()` is called in the event handler of a `drain` event, `Buffer` can write things twice.

Example:

``` php
$buffer = new Buffer();
$buffer->once('drain', function ($buffer) {
    $buffer->write("bar\n");
});

$buffer->write("foo\n");
```

This write `"foo\nfoo\nbar\n"` instead of just `"foo\nbar\n"`.

This doesn't happen if `$buffer->write("bar\n");` is called on the next tick (which explains why it usually works).

This happens in actual code, e.g. when using `Util::pipe()` on a Readable which immediately emits a `'data'` event when `resume()` is called.

This PR fixes this by updating the internal buffer before emitting the `drain` event.