### PR TITLE
BufferedSink: Remove progress notifications

### DIFF
--- a/src/BufferedSink.php
+++ b/src/BufferedSink.php
@@ -31,7 +31,6 @@ class BufferedSink extends WritableStream implements PromisorInterface
     public function write($data)
     {
         $this->buffer .= $data;
-        $this->deferred->progress($data);
     }
 
     public function close()

--- a/tests/BufferedSinkTest.php
+++ b/tests/BufferedSinkTest.php
@@ -107,21 +107,12 @@ class BufferedSinkTest extends TestCase
     }
 
     /** @test */
-    public function writeShouldTriggerProgressOnPromise()
+    public function writeShouldNotTriggerProgressOnPromise()
     {
         $callback = $this->createCallableMock();
         $callback
-            ->expects($this->at(0))
-            ->method('__invoke')
-            ->with('foo');
-        $callback
-            ->expects($this->at(1))
-            ->method('__invoke')
-            ->with('bar');
-        $callback
-            ->expects($this->at(2))
-            ->method('__invoke')
-            ->with('baz');
+            ->expects($this->never())
+            ->method('__invoke');
 
         $sink = new BufferedSink();
         $sink
@@ -129,8 +120,6 @@ class BufferedSinkTest extends TestCase
             ->then(null, null, $callback);
 
         $sink->write('foo');
-        $sink->write('bar');
-        $sink->end('baz');
     }
 
     /** @test */


### PR DESCRIPTION
This PR removes triggering progress notifications on the promise returned by BufferedSink.

I always recommend to avoid the progression API of promises (it's underspecified, has subtle problems and has little to do with promises). 

If you need to listen on data events, use the ReadableStream directly.