### PR TITLE
Prevent infinite loop on connection close

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -87,7 +87,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         restore_error_handler();
 
-        if (false === $sent || ($sent === 0 && strpos($this->lastError['message'], 'errno=10054') !== false)) {
+        if ($this->lastError['number'] > 0) {
             $this->emit('error', array(
                 new \ErrorException(
                     $this->lastError['message'],
@@ -102,9 +102,8 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             return;
         }
 
-        if (0 === $sent && feof($this->stream)) {
-            $this->emit('error', array(new \RuntimeException('Tried to write to closed stream.'), $this));
-
+        if ($sent === false) {
+            $this->emit('error', array(new \RuntimeException('Send failed'), $this));
             return;
         }
 

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -131,11 +131,11 @@ class Buffer extends EventEmitter implements WritableStreamInterface
     }
 
     private function lastErrorFlush() {
-        $this->lastError = [
+        $this->lastError = array(
             'number'  => 0,
             'message' => '',
             'file'    => '',
             'line'    => 0,
-        ];
+        );
     }
 }

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -14,17 +14,13 @@ class Buffer extends EventEmitter implements WritableStreamInterface
     private $writable = true;
     private $loop;
     private $data = '';
-    private $lastError = array(
-        'number'  => 0,
-        'message' => '',
-        'file'    => '',
-        'line'    => 0,
-    );
+    private $lastError;
 
     public function __construct($stream, LoopInterface $loop)
     {
         $this->stream = $stream;
         $this->loop = $loop;
+        $this->lastErrorFlush();
     }
 
     public function isWritable()
@@ -83,13 +79,15 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             return;
         }
 
+        $this->lastErrorFlush();
+
         set_error_handler(array($this, 'errorHandler'));
 
         $sent = fwrite($this->stream, $this->data);
 
         restore_error_handler();
 
-        if (false === $sent) {
+        if (false === $sent || ($sent === 0 && strpos($this->lastError['message'], 'errno=10054') !== false)) {
             $this->emit('error', array(
                 new \ErrorException(
                     $this->lastError['message'],
@@ -131,5 +129,14 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         $this->lastError['message'] = $errstr;
         $this->lastError['file']    = $errfile;
         $this->lastError['line']    = $errline;
+    }
+
+    private function lastErrorFlush() {
+        $this->lastError = [
+            'number'  => 0,
+            'message' => '',
+            'file'    => '',
+            'line'    => 0,
+        ];
     }
 }

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -208,7 +208,7 @@ class BufferTest extends TestCase
         $buffer->write('bar');
 
         $this->assertInstanceOf('Exception', $error);
-        $this->assertSame('Tried to write to closed stream.', $error->getMessage());
+        $this->assertSame('fwrite(): send of 3 bytes failed with errno=32 Broken pipe', $error->getMessage());
     }
 
     private function createWriteableLoopMock()


### PR DESCRIPTION
Hi.
I have Ratchet working 24/7 and sometimes it starting to use 100% of CPU. In this case I need to restart it and this helps. But it happend very often, so I debug it and found that `foef($this->stream)` do not return `true` when client disconnects while event loop tick is not ended. 
Same with `is_resource($this->stream)` it returns `true`.

I'm using:
- PHP 5.5.13 / Win8 x64
- PHP 5.4.10 / Win7 x64
- react/event-loop 0.4.1
- react/socket 0.4.2
- react/stream 0.4.2
- cboden/ratchet 0.3.3

In this case after
```php
$sent = fwrite($this->stream, $this->data);
```
`$this->lastError['message']` contains an error:

![grabilla ya9688](https://cloud.githubusercontent.com/assets/1250142/8466963/1b310488-2061-11e5-919c-823ee6bd1ac4.png)


There is no way to catch such behavior using best practices, so I decide to check `$this->lastError['message']` on 'errno=10054'.
Maybe it will be more efficient if we will check `$this->lastError['number']` on any error `> 0`. But to prevent just on this case I decide to check only errno=10054 in message. 

I know __this__ is not good resolution but __it works__.
