### PR TITLE
HHVM does not support, nor require, unbuffered read operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,11 @@ php:
   - 5.6
   - 7
   - hhvm
-  - hhvm-nightly
 
 matrix:
   allow_failures:
     - php: 7
     - php: hhvm
-    - php: hhvm-nightly
   fast_finish: true
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,8 @@ php:
   - 7
   - hhvm
 
-matrix:
-  allow_failures:
-    - php: 7
-    - php: hhvm
-  fast_finish: true
+install:
+  - composer install --prefer-source
 
-before_script:
-  - composer install --dev --prefer-source
-  
 script:
   - phpunit --coverage-text


### PR DESCRIPTION
PR #20 introduced changes to the buffering behavior which is necessary for some event loops, however this turned out to be incompatible with HHVM.

* [x] Ignore this for unsupported platforms (HHVM), as it's not required here
* [x] Add some background / documentation
* [x] Abort on all Travis errors (so something like this doesn't go unnoticed next time)