### PR TITLE
[RFC] Improve compatibility with legacy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "keywords": ["stream", "pipe"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
-        "evenement/evenement": "^2.0"
+        "php": ">=5.3.8",
+        "evenement/evenement": "^2.0|^1.0"
     },
     "require-dev": {
-        "react/event-loop": "^0.4",
-        "react/promise": "^2.0"
+        "react/event-loop": "^0.4|^0.3",
+        "react/promise": "^2.0|^1.0"
     },
     "suggest": {
         "react/event-loop": "^0.4",

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -72,7 +72,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         $this->listening = false;
         $this->data = '';
 
-        $this->emit('close', [$this]);
+        $this->emit('close', array($this));
     }
 
     public function handleWrite()
@@ -112,7 +112,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         $len = strlen($this->data);
         if ($len >= $this->softLimit && $len - $sent < $this->softLimit) {
-            $this->emit('drain', [$this]);
+            $this->emit('drain', array($this));
         }
 
         $this->data = (string) substr($this->data, $sent);
@@ -121,7 +121,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             $this->loop->removeWriteStream($this->stream);
             $this->listening = false;
 
-            $this->emit('full-drain', [$this]);
+            $this->emit('full-drain', array($this));
         }
     }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -29,13 +29,15 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $this->loop = $loop;
         $this->buffer = new Buffer($this->stream, $this->loop);
 
-        $this->buffer->on('error', function ($error) {
-            $this->emit('error', array($error, $this));
-            $this->close();
+        $that = $this;
+
+        $this->buffer->on('error', function ($error) use ($that) {
+            $that->emit('error', array($error, $that));
+            $that->close();
         });
 
-        $this->buffer->on('drain', function () {
-            $this->emit('drain', array($this));
+        $this->buffer->on('drain', function () use ($that) {
+            $that->emit('drain', array($that));
         });
 
         $this->resume();
@@ -103,9 +105,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $this->readable = false;
         $this->writable = false;
 
-        $this->buffer->on('close', function () {
-            $this->close();
-        });
+        $this->buffer->on('close', array($this, 'close'));
 
         $this->buffer->end($data);
     }

--- a/tests/StreamIntegrationTest.php
+++ b/tests/StreamIntegrationTest.php
@@ -9,12 +9,12 @@ class StreamIntegrationTest extends TestCase
 {
     public function loopProvider()
     {
-        return [
-            [function() { return true; }, function() { return new rel\StreamSelectLoop; }],
-            [function() { return function_exists('event_base_new'); }, function() { return new rel\LibEventLoop; }],
-            [function() { return class_exists('libev\EventLoop'); }, function() { return new rel\LibEvLoop; }],
-            [function() { return class_exists('EventBase'); }, function() { return new rel\ExtEventLoop; }]
-        ];
+        return array(
+            array(function() { return true; }, function() { return new rel\StreamSelectLoop; }),
+            array(function() { return function_exists('event_base_new'); }, function() { return new rel\LibEventLoop; }),
+            array(function() { return class_exists('libev\EventLoop'); }, function() { return new rel\LibEvLoop; }),
+            array(function() { return class_exists('EventBase'); }, function() { return new rel\ExtEventLoop; })
+        );
     }
 
     /**


### PR DESCRIPTION
Because *why not*… :-)

Now more seriously: This project is a low level lib that is used as a building block for quite a few higher level abstractions on top of it. As such, compatibility (even with significantly outdated versions) is a major concern to me.

Note that I'm not suggesting putting *significant amount* of work into this. The patch is already here and, personally, I see little harm in supporting this.

Also note that I'm not suggesting we need to keep support indefinitely. Should this ever turn out to be a burden in the future, e.g. because we actually *require* any new language features or some external lib, then I'm all for dropping support again.