### PR TITLE
Emit error and close when reading from stream fails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     },
     "require-dev": {
         "react/event-loop": "^0.4|^0.3",
-        "react/promise": "^2.0|^1.0"
+        "react/promise": "^2.0|^1.0",
+        "clue/stream-filter": "~1.2"
     },
     "suggest": {
         "react/event-loop": "^0.4",

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Stream;
 
 use React\Stream\Stream;
+use Clue\StreamFilter as Filter;
 
 class StreamTest extends TestCase
 {
@@ -120,6 +121,62 @@ class StreamTest extends TestCase
         $conn->on('data', function ($data, $stream) {
             $stream->close();
         });
+
+        fwrite($stream, "foobar\n");
+        rewind($stream);
+
+        $conn->handleData($stream);
+    }
+
+    /**
+     * @covers React\Stream\Stream::handleData
+     */
+    public function testDataFiltered()
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        // add a filter which removes every 'a' when reading
+        Filter\append($stream, function ($chunk) {
+            return str_replace('a', '', $chunk);
+        }, STREAM_FILTER_READ);
+
+        $loop = $this->createLoopMock();
+
+        $capturedData = null;
+
+        $conn = new Stream($stream, $loop);
+        $conn->on('data', function ($data) use (&$capturedData) {
+            $capturedData = $data;
+        });
+
+        fwrite($stream, "foobar\n");
+        rewind($stream);
+
+        $conn->handleData($stream);
+        $this->assertSame("foobr\n", $capturedData);
+    }
+
+    /**
+     * @covers React\Stream\Stream::handleData
+     */
+    public function testDataErrorShouldEmitErrorAndClose()
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        // add a filter which returns an error when encountering an 'a' when reading
+        Filter\append($stream, function ($chunk) {
+            if (strpos($chunk, 'a') !== false) {
+                throw new \Exception('Invalid');
+            }
+            return $chunk;
+        }, STREAM_FILTER_READ);
+
+        $loop = $this->createLoopMock();
+
+        $conn = new Stream($stream, $loop);
+        $conn->on('data', $this->expectCallableNever());
+        $conn->on('error', $this->expectCallableOnce());
+        $conn->on('close', $this->expectCallableOnce());
 
         fwrite($stream, "foobar\n");
         rewind($stream);


### PR DESCRIPTION
Make sure any read error is handled just like write errors and results in an `error` event followed by closing the stream instance.

```
fread(): SSL: Connection reset by peer
fread(): {x} is not a valid stream resource
```

Fixes #18.