### PR TITLE
Add benchmarking script to measure throughput in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ install:
 
 script:
   - phpunit --coverage-text
+  - time php examples/benchmark-throughput.php

--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -1,0 +1,33 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$args = getopt('i:o:t:');
+$if = isset($args['i']) ? $args['i'] : '/dev/zero';
+$of = isset($args['o']) ? $args['o'] : '/dev/null';
+$t  = isset($args['t']) ? $args['t'] : 1;
+
+echo 'piping for ' . $t . ' second(s) from ' . $if . ' to ' . $of . '...'. PHP_EOL;
+
+$loop = new React\EventLoop\StreamSelectLoop();
+
+// setup input and output streams and pipe inbetween
+$in = new React\Stream\Stream(fopen($if, 'r'), $loop);
+$out = new React\Stream\Stream(fopen($of, 'w'), $loop);
+$out->pause();
+$in->pipe($out);
+
+// count number of bytes from input stream
+$bytes = 0;
+$in->on('data', function ($chunk) use (&$bytes) {
+    $bytes += strlen($chunk);
+});
+
+// stop input stream in $t seconds
+$loop->addTimer($t, function () use ($in) {
+    $in->close();
+});
+
+$loop->run();
+
+echo 'read ' . $bytes . ' byte(s) in ' . $t . ' second(s) => ' . round($bytes / 1024 / 1024 / $t, 1) . ' MiB/s' . PHP_EOL;

--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -7,6 +7,10 @@ $if = isset($args['i']) ? $args['i'] : '/dev/zero';
 $of = isset($args['o']) ? $args['o'] : '/dev/null';
 $t  = isset($args['t']) ? $args['t'] : 1;
 
+// passing file descriptors requires mapping paths (https://bugs.php.net/bug.php?id=53465)
+$if = str_replace('/dev/fd/', 'php://fd/', $if);
+$of = str_replace('/dev/fd/', 'php://fd/', $of);
+
 echo 'piping for ' . $t . ' second(s) from ' . $if . ' to ' . $of . '...'. PHP_EOL;
 
 $loop = new React\EventLoop\StreamSelectLoop();

--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -16,6 +16,9 @@ $loop = new React\EventLoop\StreamSelectLoop();
 // setup information stream
 $info = new React\Stream\Stream(STDERR, $loop);
 $info->pause();
+if (extension_loaded('xdebug')) {
+    $info->write('NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL);
+}
 $info->write('piping from ' . $if . ' to ' . $of . ' (for max ' . $t . ' second(s)) ...'. PHP_EOL);
 
 // setup input and output streams and pipe inbetween

--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -41,6 +41,7 @@ $in->on('close', function () use ($in, $start, $timeout, $info) {
     $bytes = ftell($in->stream);
 
     $info->write('read ' . $bytes . ' byte(s) in ' . round($t, 3) . ' second(s) => ' . round($bytes / 1024 / 1024 / $t, 1) . ' MiB/s' . PHP_EOL);
+    $info->write('peak memory usage of ' . round(memory_get_peak_usage(true) / 1024 / 1024, 1) . ' MiB' . PHP_EOL);
 });
 
 $loop->run();


### PR DESCRIPTION
Add benchmarking script to measure throughput in CI. This gives some interesting insights into differences between PHP versions / HHVM.

Also, this serves as the basis for future performance improvements.