### PR TITLE
Support setting buffer size to null (infinite)

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -8,7 +8,11 @@ use InvalidArgumentException;
 
 class Stream extends EventEmitter implements DuplexStreamInterface
 {
+    /**
+     * @var int|null maximum buffer size in bytes to read at once or null=infinite, until reaching EOF
+     */
     public $bufferSize = 4096;
+
     public $stream;
     protected $readable = true;
     protected $writable = true;
@@ -139,7 +143,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
             );
         });
 
-        $data = fread($stream, $this->bufferSize);
+        $data = stream_get_contents($stream, $this->bufferSize === null ? -1 : $this->bufferSize);
 
         restore_error_handler();
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -9,7 +9,20 @@ use InvalidArgumentException;
 class Stream extends EventEmitter implements DuplexStreamInterface
 {
     /**
-     * @var int|null maximum buffer size in bytes to read at once or null=infinite, until reaching EOF
+     * Controls the maximum buffer size in bytes to ready at once from the stream.
+     *
+     * This can be a positive number which means that up to X bytes will be read
+     * at once from the underlying stream resource. Note that the actual number
+     * of bytes read may be lower if the stream resource has less than X bytes
+     * currently available.
+     *
+     * This can be `null` which means read everything available from the
+     * underlying stream resource.
+     * This should read until the stream resource is not readable anymore
+     * (i.e. underlying buffer drained), note that this does not neccessarily
+     * mean it reached EOF.
+     *
+     * @var int|null
      */
     public $bufferSize = 4096;
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -77,6 +77,33 @@ class StreamTest extends TestCase
     }
 
     /**
+     * @covers React\Stream\Stream::__construct
+     * @covers React\Stream\Stream::handleData
+     */
+    public function testDataEventDoesEmitOneChunkUntilStreamEndsWhenBufferSizeIsInfinite()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $capturedData = null;
+
+        $conn = new Stream($stream, $loop);
+        $conn->bufferSize = null;
+
+        $conn->on('data', function ($data) use (&$capturedData) {
+            $capturedData = $data;
+        });
+
+        fwrite($stream, str_repeat("a", 100000));
+        rewind($stream);
+
+        $conn->handleData($stream);
+
+        $this->assertFalse($conn->isReadable());
+        $this->assertEquals(100000, strlen($capturedData));
+    }
+
+    /**
      * @covers React\Stream\Stream::handleData
      */
     public function testEmptyStreamShouldNotEmitData()

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -52,6 +52,31 @@ class StreamTest extends TestCase
     }
 
     /**
+     * @covers React\Stream\Stream::__construct
+     * @covers React\Stream\Stream::handleData
+     */
+    public function testDataEventDoesEmitOneChunkMatchingBufferSize()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $capturedData = null;
+
+        $conn = new Stream($stream, $loop);
+        $conn->on('data', function ($data) use (&$capturedData) {
+            $capturedData = $data;
+        });
+
+        fwrite($stream, str_repeat("a", 100000));
+        rewind($stream);
+
+        $conn->handleData($stream);
+
+        $this->assertTrue($conn->isReadable());
+        $this->assertEquals($conn->bufferSize, strlen($capturedData));
+    }
+
+    /**
      * @covers React\Stream\Stream::handleData
      */
     public function testEmptyStreamShouldNotEmitData()


### PR DESCRIPTION
This has no effect by default and can be triggered by setting `bufferSize` to `null`.

This can result in huge performance improvements without causing any memory issues if the buffer size is limited by the underlying OS anyway (such as when reading from a TCP/IP socket).

Also, this can be used to avoid some SSL/TLS hackery in our socket-client component: https://github.com/reactphp/socket-client/blob/f905ec2a576b1242b10d5c1dbd2f0eb4fcea7f0c/src/SecureStream.php#L44
