### PR TITLE
Revert "BufferedSink: Remove progress notifications"

### DIFF
--- a/src/BufferedSink.php
+++ b/src/BufferedSink.php
@@ -31,6 +31,7 @@ class BufferedSink extends WritableStream implements PromisorInterface
     public function write($data)
     {
         $this->buffer .= $data;
+        $this->deferred->progress($data);
     }
 
     public function close()

--- a/tests/BufferedSinkTest.php
+++ b/tests/BufferedSinkTest.php
@@ -107,12 +107,21 @@ class BufferedSinkTest extends TestCase
     }
 
     /** @test */
-    public function writeShouldNotTriggerProgressOnPromise()
+    public function writeShouldTriggerProgressOnPromise()
     {
         $callback = $this->createCallableMock();
         $callback
-            ->expects($this->never())
-            ->method('__invoke');
+            ->expects($this->at(0))
+            ->method('__invoke')
+            ->with('foo');
+        $callback
+            ->expects($this->at(1))
+            ->method('__invoke')
+            ->with('bar');
+        $callback
+            ->expects($this->at(2))
+            ->method('__invoke')
+            ->with('baz');
 
         $sink = new BufferedSink();
         $sink
@@ -120,6 +129,8 @@ class BufferedSinkTest extends TestCase
             ->then(null, null, $callback);
 
         $sink->write('foo');
+        $sink->write('bar');
+        $sink->end('baz');
     }
 
     /** @test */


### PR DESCRIPTION
Reverts reactphp/stream#24, because it currently blocks a v0.4.4 release. In other words: This restores the behavior present in the last v0.4.3 release.

I think we all agree that we want to remove the progress notifications, however this includes a BC break and thus should target a future v0.5.0 milestone.