### PR TITLE
Enforce using non-blocking I/O

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -21,6 +21,12 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
+        // this class relies on non-blocking I/O in order to not interrupt the event loop
+        // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
+        if (stream_set_blocking($stream, 0) !== true) {
+            throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
+        }
+
         $this->stream = $stream;
         $this->loop = $loop;
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -40,7 +40,11 @@ class Stream extends EventEmitter implements DuplexStreamInterface
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
-        stream_set_blocking($this->stream, 0);
+        // this class relies on non-blocking I/O in order to not interrupt the event loop
+        // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
+        if (stream_set_blocking($this->stream, 0) !== true) {
+            throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
+        }
 
         // Use unbuffered read operations on the underlying stream resource.
         // Reading chunks from the stream may otherwise leave unread bytes in

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -35,14 +35,13 @@ class Stream extends EventEmitter implements DuplexStreamInterface
 
     public function __construct($stream, LoopInterface $loop, WritableStreamInterface $buffer = null)
     {
-        $this->stream = $stream;
-        if (!is_resource($this->stream) || get_resource_type($this->stream) !== "stream") {
+        if (!is_resource($stream) || get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
         // this class relies on non-blocking I/O in order to not interrupt the event loop
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
-        if (stream_set_blocking($this->stream, 0) !== true) {
+        if (stream_set_blocking($stream, 0) !== true) {
             throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
         }
 
@@ -53,13 +52,14 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         // This does not affect the default event loop implementation (level
         // triggered), so we can ignore platforms not supporting this (HHVM).
         if (function_exists('stream_set_read_buffer')) {
-            stream_set_read_buffer($this->stream, 0);
+            stream_set_read_buffer($stream, 0);
         }
 
         if ($buffer === null) {
             $buffer = new Buffer($stream, $loop);
         }
 
+        $this->stream = $stream;
         $this->loop = $loop;
         $this->buffer = $buffer;
 

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -20,13 +20,29 @@ class BufferTest extends TestCase
 
     /**
      * @covers React\Stream\Buffer::__construct
-     * @expectedException InvalidArgumentException
      */
     public function testConstructorThrowsIfNotAValidStreamResource()
     {
         $stream = null;
         $loop = $this->createLoopMock();
 
+        $this->setExpectedException('InvalidArgumentException');
+        new Buffer($stream, $loop);
+    }
+
+    /**
+     * @covers React\Stream\Buffer::__construct
+     */
+    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
+    {
+        if (!in_array('blocking', stream_get_wrappers())) {
+            stream_wrapper_register('blocking', 'React\Tests\Stream\EnforceBlockingWrapper');
+        }
+
+        $stream = fopen('blocking://test', 'r+');
+        $loop = $this->createLoopMock();
+
+        $this->setExpectedException('RuntimeException');
         new Buffer($stream, $loop);
     }
 

--- a/tests/EnforceBlockingWrapper.php
+++ b/tests/EnforceBlockingWrapper.php
@@ -2,11 +2,21 @@
 
 namespace React\Tests\Stream;
 
+/**
+ * Used to test dummy stream resources that do not support setting non-blocking mode
+ *
+ * @link http://php.net/manual/de/class.streamwrapper.php
+ */
 class EnforceBlockingWrapper
 {
     public function stream_open($path, $mode, $options, &$opened_path)
     {
         return true;
+    }
+
+    public function stream_cast($cast_as)
+    {
+        return false;
     }
 
     public function stream_set_option($option, $arg1, $arg2)

--- a/tests/EnforceBlockingWrapper.php
+++ b/tests/EnforceBlockingWrapper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace React\Tests\Stream;
+
+class EnforceBlockingWrapper
+{
+    public function stream_open($path, $mode, $options, &$opened_path)
+    {
+        return true;
+    }
+
+    public function stream_set_option($option, $arg1, $arg2)
+    {
+        if ($option === STREAM_OPTION_BLOCKING) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -23,9 +23,26 @@ class StreamTest extends TestCase
      */
     public function testConstructorThrowsExceptionOnInvalidStream()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $loop = $this->createLoopMock();
-        $conn = new Stream('breakme', $loop);
+
+        $this->setExpectedException('InvalidArgumentException');
+        new Stream('breakme', $loop);
+    }
+
+    /**
+     * @covers React\Stream\Stream::__construct
+     */
+    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
+    {
+        if (!in_array('blocking', stream_get_wrappers())) {
+            stream_wrapper_register('blocking', 'React\Tests\Stream\EnforceBlockingWrapper');
+        }
+
+        $stream = fopen('blocking://test', 'r+');
+        $loop = $this->createLoopMock();
+
+        $this->setExpectedException('RuntimeException');
+        new Stream($stream, $loop);
     }
 
     /**


### PR DESCRIPTION
Opening this an RFC, any input is welcome! :+1: 

Reading from a stream should _never_ block the loop.
This is known to be an issue for process pipes on Windows.

Refs: https://github.com/reactphp/child-process/issues/9 and https://github.com/reactphp/react/issues/68
