### PR TITLE
Use softLimit to write, for heavy payload and SSL, on high latency, l…

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -83,7 +83,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         set_error_handler(array($this, 'errorHandler'));
 
-        $sent = fwrite($this->stream, $this->data);
+        $sent = fwrite($this->stream, $this->data, $this->softLimit);
 
         restore_error_handler();
 


### PR DESCRIPTION
…ow bandwidth internet, it seems to mitigate SSL related issues to some extent.

The bug is described in details here:
https://bugs.php.net/bug.php?id=72333

The issue is that PHP doesn't handle SSL's NEED_READ when writing to SSL stream, which expects us to retry with the same buffer. When smaller message chuncks are sent, it forces the library to check for readable and writable stream, and this seems to mitigate this issue to some extent. Lower the value even more, if this seems to be too high.

NOTE: You might want to use `stream_set_write_buffer` to set the stream's buffer to 0, just to make sure PHP doesn't buffer the write.