### PR TITLE
Ignore empty writes to Buffer

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -36,7 +36,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         $this->data .= $data;
 
-        if (!$this->listening) {
+        if (!$this->listening && $this->data !== '') {
             $this->listening = true;
 
             $this->loop->addWriteStream($this->stream, array($this, 'handleWrite'));

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -37,6 +37,36 @@ class BufferTest extends TestCase
 
     /**
      * @covers React\Stream\Buffer::write
+     */
+    public function testWriteWithDataDoesAddResourceToLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addWriteStream')->with($this->equalTo($stream));
+
+        $buffer = new Buffer($stream, $loop);
+
+        $buffer->write("foobar\n");
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
+     * @covers React\Stream\Buffer::handleWrite
+     */
+    public function testEmptyWriteDoesNotAddToLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->never())->method('addWriteStream');
+
+        $buffer = new Buffer($stream, $loop);
+
+        $buffer->write("");
+        $buffer->write(null);
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
      * @covers React\Stream\Buffer::handleWrite
      */
     public function testWriteReturnsFalseWhenBufferIsFull()


### PR DESCRIPTION
Empty writes should not wait for writable event from the event loop and then literally try to do *nothing*.

Without this change, it would otherwise wait for the Buffer to return from a superfluous `fwrite($resource, '')` call.