### PR TITLE
Only emit permanent errors and otherwise keep retrying

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -102,7 +102,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             return;
         }
 
-        if ($sent === false) {
+        if ($sent === 0) {
             $this->emit('error', array(new \RuntimeException('Send failed'), $this));
             return;
         }

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -87,7 +87,14 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         restore_error_handler();
 
-        if ($this->lastError['number'] > 0) {
+        // Only report errors if *nothing* could be sent.
+        // Any hard (permanent) error will fail to send any data at all.
+        // Sending excessive amounts of data will only flush *some* data and then
+        // report a temporary error (EAGAIN) which we do not raise here in order
+        // to keep the stream open for further tries to write.
+        // Should this turn out to be a permanent error later, it will eventually
+        // send *nothing* and we can detect this.
+        if ($sent === 0 && $this->lastError['number'] > 0) {
             $this->emit('error', array(
                 new \ErrorException(
                     $this->lastError['message'],

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -60,6 +60,11 @@ class BufferTest extends TestCase
      */
     public function testWriteEmitsErrorWhenResourceIsNotWritable()
     {
+        if (defined('HHVM_VERSION')) {
+            // via https://github.com/reactphp/stream/pull/52/files#r75493076
+            $this->markTestSkipped('HHVM allows writing to read-only memory streams');
+        }
+
         $stream = fopen('php://temp', 'r');
         $loop = $this->createLoopMock();
 

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -58,6 +58,23 @@ class BufferTest extends TestCase
      * @covers React\Stream\Buffer::write
      * @covers React\Stream\Buffer::handleWrite
      */
+    public function testWriteEmitsErrorWhenResourceIsNotWritable()
+    {
+        $stream = fopen('php://temp', 'r');
+        $loop = $this->createLoopMock();
+
+        $buffer = new Buffer($stream, $loop);
+        $buffer->on('error', $this->expectCallableOnce());
+        //$buffer->on('close', $this->expectCallableOnce());
+
+        $buffer->write('hello');
+        $buffer->handleWrite();
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
+     * @covers React\Stream\Buffer::handleWrite
+     */
     public function testWriteDetectsWhenOtherSideIsClosed()
     {
         list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);


### PR DESCRIPTION
Only report errors if *nothing* could be sent.

Any hard (permanent) error will fail to send any data at all.
Sending excessive amounts of data will only flush *some* data and then
report a temporary error (EAGAIN) which we do not raise here in order
to keep the stream open for further tries to write.

Should this turn out to be a permanent error later, it will eventually
send *nothing* and we can detect this.

This fixes a (very sublte) regression introduced via #25.
This also adds a bunch of unit tests so we hopefully no longer rely on any external test cases. The Buffer now has 100% code coverage in our tests.

I've intentionally kept this changeset to a minimum in order to ease review. I'll file a second PR to streamline the error handling system after this PR is in.

Also note that this changeset has an implicit dependency on #51, empty writes would otherwise raise an error event (see that PR for more details).