### PR TITLE
Increase performance by raising default buffer sizes to 64 KiB

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -10,7 +10,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 {
     public $stream;
     public $listening = false;
-    public $softLimit = 2048;
+    public $softLimit = 65536;
     private $writable = true;
     private $loop;
     private $data = '';

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 
 class Stream extends EventEmitter implements DuplexStreamInterface
 {
-    public $bufferSize = 4096;
+    public $bufferSize = 65536;
     public $stream;
     protected $readable = true;
     protected $writable = true;


### PR DESCRIPTION
The readable and writable side now use the same buffer sizes in order to avoid pausing the readable side when piping to a writable stream.

Running the `examples/benchmark-throughput.php` script, this change alone increases performance from ~100 MiB/s to ~1400 MiB/s on my (rather mediocre) test system, using PHP 7.0.8.

A buffer size of 64 KiB is a reasonable compromise between memory usage and performance, and the total buffer sizes can still be neglected even with thousands of open streams.
