### PR TITLE
[WIP] Immediate writes to underlying stream until buffer is filled

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -42,6 +42,8 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             $this->listening = true;
 
             $this->loop->addWriteStream($this->stream, array($this, 'handleWrite'));
+
+            $this->handleWrite();
         }
 
         return !isset($this->data[$this->softLimit - 1]);

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -123,7 +123,7 @@ class StreamTest extends TestCase
     public function testWrite()
     {
         $stream = fopen('php://temp', 'r+');
-        $loop = $this->createWriteableLoopMock();
+        $loop = $this->createLoopMock();
 
         $conn = new Stream($stream, $loop);
         $conn->write("foo\n");
@@ -234,19 +234,6 @@ class StreamTest extends TestCase
         rewind($stream);
 
         $conn->handleData($stream);
-    }
-
-    private function createWriteableLoopMock()
-    {
-        $loop = $this->createLoopMock();
-        $loop
-            ->expects($this->once())
-            ->method('addWriteStream')
-            ->will($this->returnCallback(function ($stream, $listener) {
-                call_user_func($listener, $stream);
-            }));
-
-        return $loop;
     }
 
     private function createLoopMock()


### PR DESCRIPTION
With this change applied, the `Buffer` will immediately write to the underlying stream instead of waiting for the loop to say it it writable. This is safe because the stream is non-blocking anyway and the Buffer class will return to normal buffer behavior once the data can not be flushed immediately.

Running the examples/benchmark-throughput.php script, this change alone increases performance from ~100 MiB/s to ~160 MiB/s on my (rather mediocre) test system, using PHP 7.0.8.
Combined with #53, it increases performance from ~100 MiB/s to ~1900 MiB/s.

~~Marking this as WIP because this needs some additional tests once #52 is in.~~ Edit: done.
