### PR TITLE
Do not emit full-drain event if Buffer is closed during drain event

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -110,11 +110,13 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         $len = strlen($this->data);
         $this->data = (string) substr($this->data, $sent);
 
+        // buffer has been above limit and is now below limit
         if ($len >= $this->softLimit && $len - $sent < $this->softLimit) {
             $this->emit('drain', array($this));
         }
 
-        if (0 === strlen($this->data)) {
+        // buffer is now completely empty (and not closed already)
+        if (0 === strlen($this->data) && $this->listening) {
             $this->loop->removeWriteStream($this->stream);
             $this->listening = false;
 

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -86,6 +86,20 @@ class BufferTest extends TestCase
 
     /**
      * @covers React\Stream\Buffer::write
+     */
+    public function testWriteReturnsFalseWhenBufferIsExactlyFull()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = new Buffer($stream, $loop);
+        $buffer->softLimit = 3;
+
+        $this->assertFalse($buffer->write("foo"));
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
      * @covers React\Stream\Buffer::handleWrite
      */
     public function testWriteDetectsWhenOtherSideIsClosed()

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -130,8 +130,6 @@ class BufferTest extends TestCase
      */
     public function testWriteInDrain()
     {
-        $writeStreams = array();
-
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createWriteableLoopMock();
         $loop->preventWrites = true;
@@ -152,6 +150,47 @@ class BufferTest extends TestCase
 
         fseek($stream, 0);
         $this->assertSame("foo\nbar\n", stream_get_contents($stream));
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
+     * @covers React\Stream\Buffer::handleWrite
+     */
+    public function testDrainAndFullDrainAfterWrite()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = new Buffer($stream, $loop);
+        $buffer->softLimit = 2;
+
+        $buffer->on('drain', $this->expectCallableOnce());
+        $buffer->on('full-drain', $this->expectCallableOnce());
+
+        $buffer->write("foo");
+        $buffer->handleWrite();
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
+     * @covers React\Stream\Buffer::handleWrite
+     */
+    public function testCloseDuringDrainWillNotEmitFullDrain()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = new Buffer($stream, $loop);
+        $buffer->softLimit = 2;
+
+        // close buffer on drain event => expect close event, but no full-drain after
+        $buffer->on('drain', $this->expectCallableOnce());
+        $buffer->on('drain', array($buffer, 'close'));
+        $buffer->on('close', $this->expectCallableOnce());
+        $buffer->on('full-drain', $this->expectCallableNever());
+
+        $buffer->write("foo");
+        $buffer->handleWrite();
     }
 
     /**


### PR DESCRIPTION
The `Buffer` can be closed during the `drain` event, do not emit any further events in this case.
This is a very subtle bug and unlikely to ever have caused any real issues, but let's fix this for consistency.

Also, while we're at this, let's avoid some unnecessary function calls and improve performance a bit :)
Do not expect any major performance improvements here.

Running the examples/benchmark-throughput.php script, this change alone increases performance from ~100 MiB/s to ~110 MiB/s on my (rather mediocre) test system, using PHP 7.0.8.
Combined with #53 and #54, it increases performance from ~100 MiB/s to ~1950 MiB/s.

If you want to review, consider looking at the individual commits, this should make the changes pretty obvious.
