### PR TITLE
Simplify and improve error handling

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -77,12 +77,11 @@ class Buffer extends EventEmitter implements WritableStreamInterface
     {
         $error = null;
         set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
-            $error = new \ErrorException(
-                $errstr,
-                0,
-                $errno,
-                $errfile,
-                $errline
+            $error = array(
+                'message' => $errstr,
+                'number' => $errno,
+                'file' => $errfile,
+                'line' => $errline
             );
         });
 
@@ -100,6 +99,14 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         if ($sent === 0 || $sent === false) {
             if ($error === null) {
                 $error = new \RuntimeException('Send failed');
+            } else {
+                $error = new \ErrorException(
+                    $error['message'],
+                    0,
+                    $error['number'],
+                    $error['file'],
+                    $error['line']
+                );
             }
 
             $this->emit('error', array(new \RuntimeException('Unable to write to stream: ' . $error->getMessage(), 0, $error), $this));

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -249,7 +249,6 @@ class BufferTest extends TestCase
 
     /**
      * @covers React\Stream\Buffer::handleWrite
-     * @covers React\Stream\Buffer::errorHandler
      */
     public function testError()
     {
@@ -290,7 +289,7 @@ class BufferTest extends TestCase
         $buffer->write('bar');
 
         $this->assertInstanceOf('Exception', $error);
-        $this->assertSame('fwrite(): send of 3 bytes failed with errno=32 Broken pipe', $error->getMessage());
+        $this->assertSame('Unable to write to stream: fwrite(): send of 3 bytes failed with errno=32 Broken pipe', $error->getMessage());
     }
 
     private function createWriteableLoopMock()


### PR DESCRIPTION
This only cleans up some of the internals and avoids some unnecessary function calls.

Running the examples/benchmark-throughput.php script, this change alone increases performance from ~100 MiB/s to ~120 MiB/s on my (rather mediocre) test system, using PHP 7.0.8.
Combined with #53, #54 and #55, it increases performance from ~100 MiB/s to ~2000 MiB/s.

If you want to review, consider looking at the individual commits, this should make the changes pretty obvious.

~~Marking this as WIP because this will need to be rebased once #52 is in.~~ Edit: done.
