### PR TITLE
Consistent close behavior for Buffer

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -69,9 +69,13 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             return;
         }
 
+        if ($this->listening) {
+            $this->listening = false;
+            $this->loop->removeWriteStream($this->stream);
+        }
+
         $this->closed = true;
         $this->writable = false;
-        $this->listening = false;
         $this->data = '';
 
         $this->emit('close', array($this));

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -114,6 +114,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
             }
 
             $this->emit('error', array(new \RuntimeException('Unable to write to stream: ' . $error->getMessage(), 0, $error), $this));
+            $this->close();
 
             return;
         }

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -79,6 +79,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         $this->data = '';
 
         $this->emit('close', array($this));
+        $this->removeAllListeners();
     }
 
     public function handleWrite()

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -12,6 +12,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
     public $listening = false;
     public $softLimit = 65536;
     private $writable = true;
+    private $closed = false;
     private $loop;
     private $data = '';
 
@@ -64,6 +65,11 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
     public function close()
     {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
         $this->writable = false;
         $this->listening = false;
         $this->data = '';

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -79,6 +79,20 @@ class BufferTest extends TestCase
 
     /**
      * @covers React\Stream\Buffer::write
+     */
+    public function testWriteWillAddStreamToLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $buffer = new Buffer($stream, $loop);
+
+        $loop->expects($this->once())->method('addWriteStream')->with($stream);
+
+        $buffer->write('foo');
+    }
+
+    /**
+     * @covers React\Stream\Buffer::write
      * @covers React\Stream\Buffer::handleWrite
      */
     public function testWriteReturnsFalseWhenBufferIsFull()
@@ -292,6 +306,35 @@ class BufferTest extends TestCase
         $this->assertTrue($buffer->isWritable());
         $buffer->close();
         $this->assertFalse($buffer->isWritable());
+    }
+
+    /**
+     * @covers React\Stream\Buffer::close
+     */
+    public function testClosingAfterWriteRemovesStreamFromLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $buffer = new Buffer($stream, $loop);
+
+        $loop->expects($this->once())->method('removeWriteStream')->with($stream);
+
+        $buffer->write('foo');
+        $buffer->close();
+    }
+
+    /**
+     * @covers React\Stream\Buffer::close
+     */
+    public function testClosingWithoutWritingDoesNotRemoveStreamFromLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $buffer = new Buffer($stream, $loop);
+
+        $loop->expects($this->never())->method('removeWriteStream');
+
+        $buffer->close();
     }
 
     /**

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -295,6 +295,21 @@ class BufferTest extends TestCase
     }
 
     /**
+     * @covers React\Stream\Buffer::close
+     */
+    public function testDoubleCloseWillEmitOnlyOnce()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = new Buffer($stream, $loop);
+        $buffer->on('close', $this->expectCallableOnce());
+
+        $buffer->close();
+        $buffer->close();
+    }
+
+    /**
      * @covers React\Stream\Buffer::write
      * @covers React\Stream\Buffer::close
      */

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -306,6 +306,8 @@ class BufferTest extends TestCase
         $this->assertTrue($buffer->isWritable());
         $buffer->close();
         $this->assertFalse($buffer->isWritable());
+
+        $this->assertEquals(array(), $buffer->listeners('close'));
     }
 
     /**


### PR DESCRIPTION
The `Buffer` now behaves consistently when calling its `close()` method and follows the `close` event semantics.

This is kind of a rare edge case that can not be observed in normal operation, so most people won't be affected by this bug, nor does this cause a BC break.

The `Buffer` can be accessed via `Stream::getBuffer()` or it can be created directly, in which case these errors would have shown up.