### PR TITLE
The Buffer can now be injected into the Stream (or be used standalone)

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -63,8 +63,9 @@ class Stream extends EventEmitter implements DuplexStreamInterface
 
         $this->buffer->on('error', function ($error) use ($that) {
             $that->emit('error', array($error, $that));
-            $that->close();
         });
+
+        $this->buffer->on('close', array($this, 'close'));
 
         $this->buffer->on('drain', function () use ($that) {
             $that->emit('drain', array($that));
@@ -118,7 +119,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $this->emit('end', array($this));
         $this->emit('close', array($this));
         $this->loop->removeStream($this->stream);
-        $this->buffer->removeAllListeners();
+        $this->buffer->close();
         $this->removeAllListeners();
 
         $this->handleClose();
@@ -134,8 +135,6 @@ class Stream extends EventEmitter implements DuplexStreamInterface
 
         $this->readable = false;
         $this->writable = false;
-
-        $this->buffer->on('close', array($this, 'close'));
 
         $this->buffer->end($data);
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -33,7 +33,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
     protected $loop;
     protected $buffer;
 
-    public function __construct($stream, LoopInterface $loop)
+    public function __construct($stream, LoopInterface $loop, WritableStreamInterface $buffer = null)
     {
         $this->stream = $stream;
         if (!is_resource($this->stream) || get_resource_type($this->stream) !== "stream") {
@@ -52,8 +52,12 @@ class Stream extends EventEmitter implements DuplexStreamInterface
             stream_set_read_buffer($this->stream, 0);
         }
 
+        if ($buffer === null) {
+            $buffer = new Buffer($stream, $loop);
+        }
+
         $this->loop = $loop;
-        $this->buffer = new Buffer($this->stream, $this->loop);
+        $this->buffer = $buffer;
 
         $that = $this;
 
@@ -182,6 +186,9 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         }
     }
 
+    /**
+     * @return WritableStreamInterface|Buffer
+     */
     public function getBuffer()
     {
         return $this->buffer;

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -30,6 +30,21 @@ class StreamTest extends TestCase
 
     /**
      * @covers React\Stream\Stream::__construct
+     */
+    public function testConstructorAcceptsBuffer()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = $this->getMock('React\Stream\WritableStreamInterface');
+
+        $conn = new Stream($stream, $loop, $buffer);
+
+        $this->assertSame($buffer, $conn->getBuffer());
+    }
+
+    /**
+     * @covers React\Stream\Stream::__construct
      * @covers React\Stream\Stream::handleData
      */
     public function testDataEvent()


### PR DESCRIPTION
The `Buffer` can now be injected into the `Stream` (or be used standalone). This only adds an additional parameter and otherwise preserves BC.

~~Note that this builds on top of #61, so only the last commits are part of this PR.~~ Edit: rebased now that #61 is in.