### PR TITLE
Remove custom full-drain event

### DIFF
--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -204,7 +204,7 @@ class BufferTest extends TestCase
      * @covers React\Stream\Buffer::write
      * @covers React\Stream\Buffer::handleWrite
      */
-    public function testDrainAndFullDrainAfterWrite()
+    public function testDrainAfterWrite()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
@@ -213,29 +213,6 @@ class BufferTest extends TestCase
         $buffer->softLimit = 2;
 
         $buffer->on('drain', $this->expectCallableOnce());
-        $buffer->on('full-drain', $this->expectCallableOnce());
-
-        $buffer->write("foo");
-        $buffer->handleWrite();
-    }
-
-    /**
-     * @covers React\Stream\Buffer::write
-     * @covers React\Stream\Buffer::handleWrite
-     */
-    public function testCloseDuringDrainWillNotEmitFullDrain()
-    {
-        $stream = fopen('php://temp', 'r+');
-        $loop = $this->createLoopMock();
-
-        $buffer = new Buffer($stream, $loop);
-        $buffer->softLimit = 2;
-
-        // close buffer on drain event => expect close event, but no full-drain after
-        $buffer->on('drain', $this->expectCallableOnce());
-        $buffer->on('drain', array($buffer, 'close'));
-        $buffer->on('close', $this->expectCallableOnce());
-        $buffer->on('full-drain', $this->expectCallableNever());
 
         $buffer->write("foo");
         $buffer->handleWrite();
@@ -244,7 +221,7 @@ class BufferTest extends TestCase
     /**
      * @covers React\Stream\Buffer::end
      */
-    public function testEnd()
+    public function testEndWithoutDataClosesImmediatelyIfBufferIsEmpty()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
@@ -261,19 +238,63 @@ class BufferTest extends TestCase
     /**
      * @covers React\Stream\Buffer::end
      */
-    public function testEndWithData()
+    public function testEndWithoutDataDoesNotCloseIfBufferIsFull()
     {
         $stream = fopen('php://temp', 'r+');
-        $loop = $this->createWriteableLoopMock();
+        $loop = $this->createLoopMock();
+
+        $buffer = new Buffer($stream, $loop);
+        $buffer->on('error', $this->expectCallableNever());
+        $buffer->on('close', $this->expectCallableNever());
+
+        $buffer->write('foo');
+
+        $this->assertTrue($buffer->isWritable());
+        $buffer->end();
+        $this->assertFalse($buffer->isWritable());
+    }
+
+    /**
+     * @covers React\Stream\Buffer::end
+     */
+    public function testEndWithDataClosesImmediatelyIfBufferFlushes()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
 
         $buffer = new Buffer($stream, $loop);
         $buffer->on('error', $this->expectCallableNever());
         $buffer->on('close', $this->expectCallableOnce());
 
+        $this->assertTrue($buffer->isWritable());
         $buffer->end('final words');
+        $this->assertFalse($buffer->isWritable());
 
+        $buffer->handleWrite();
         rewind($stream);
         $this->assertSame('final words', stream_get_contents($stream));
+    }
+
+    /**
+     * @covers React\Stream\Buffer::end
+     */
+    public function testEndWithDataDoesNotCloseImmediatelyIfBufferIsFull()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = new Buffer($stream, $loop);
+        $buffer->on('error', $this->expectCallableNever());
+        $buffer->on('close', $this->expectCallableNever());
+
+        $buffer->write('foo');
+
+        $this->assertTrue($buffer->isWritable());
+        $buffer->end('final words');
+        $this->assertFalse($buffer->isWritable());
+
+        rewind($stream);
+        $this->assertSame('', stream_get_contents($stream));
     }
 
     /**
@@ -301,13 +322,14 @@ class BufferTest extends TestCase
     public function testWritingToClosedBufferShouldNotWriteToStream()
     {
         $stream = fopen('php://temp', 'r+');
-        $loop = $this->createWriteableLoopMock();
+        $loop = $this->createLoopMock();
 
         $buffer = new Buffer($stream, $loop);
         $buffer->close();
 
         $buffer->write('foo');
 
+        $buffer->handleWrite();
         rewind($stream);
         $this->assertSame('', stream_get_contents($stream));
     }
@@ -346,7 +368,7 @@ class BufferTest extends TestCase
         }
 
         list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
-        $loop = $this->createWriteableLoopMock();
+        $loop = $this->createLoopMock();
 
         $error = null;
 
@@ -356,9 +378,11 @@ class BufferTest extends TestCase
         });
 
         $buffer->write('foo');
+        $buffer->handleWrite();
         stream_socket_shutdown($b, STREAM_SHUT_RD);
         stream_socket_shutdown($a, STREAM_SHUT_RD);
         $buffer->write('bar');
+        $buffer->handleWrite();
 
         $this->assertInstanceOf('Exception', $error);
         $this->assertSame('Unable to write to stream: fwrite(): send of 3 bytes failed with errno=32 Broken pipe', $error->getMessage());

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -106,7 +106,7 @@ class UtilTest extends TestCase
         $readable = new Stub\ReadableStreamStub();
 
         $stream = fopen('php://temp', 'r+');
-        $loop = $this->createWriteableLoopMock();
+        $loop = $this->createLoopMock();
         $buffer = new Buffer($stream, $loop);
 
         $readable->pipe($buffer);
@@ -114,6 +114,7 @@ class UtilTest extends TestCase
         $readable->write('hello, I am some ');
         $readable->write('random data');
 
+        $buffer->handleWrite();
         rewind($stream);
         $this->assertSame('hello, I am some random data', stream_get_contents($stream));
     }
@@ -130,19 +131,6 @@ class UtilTest extends TestCase
 
         $source->emit('data', array('hello'));
         $source->emit('foo', array('bar'));
-    }
-
-    private function createWriteableLoopMock()
-    {
-        $loop = $this->createLoopMock();
-        $loop
-            ->expects($this->any())
-            ->method('addWriteStream')
-            ->will($this->returnCallback(function ($stream, $listener) {
-                call_user_func($listener, $stream);
-            }));
-
-        return $loop;
     }
 
     private function createLoopMock()


### PR DESCRIPTION
Remove the `full-drain` event from the `Buffer` and instead close as appropriate internally. This event is currently only used to `end()` the buffer. This does not change any of the outside behavior otherwise.

While not used anywhere in React's ecosystem, this is still a BC break because others may actually rely on this event. However, this event has never been documented anyway, so chances are nobody will be affected by this BC break.