### PR TITLE
Consistent event arguments and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This component depends on `événement`, which is an implementation of the
 * `data`: Emitted whenever data was read from the source
   with a single mixed argument for incoming data.
 * `end`: Emitted when the source has reached the `eof`.
-* `error`: Emitted when an error occurs.
+* `error`: Emitted when an error occurs
   with a single `Exception` argument for error instance.
 * `close`: Emitted when the connection is closed.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ This component depends on `événement`, which is an implementation of the
 
 ### EventEmitter Events
 
-* `data`: Emitted whenever data was read from the source.
+* `data`: Emitted whenever data was read from the source
+  with a single mixed argument for incoming data.
 * `end`: Emitted when the source has reached the `eof`.
 * `error`: Emitted when an error occurs.
+  with a single `Exception` argument for error instance.
 * `close`: Emitted when the connection is closed.
 
 ### Methods
@@ -42,9 +44,11 @@ This component depends on `événement`, which is an implementation of the
 
 * `drain`: Emitted if the write buffer became full previously and is now ready
   to accept more data.
-* `error`: Emitted whenever an error occurs.
+* `error`: Emitted whenever an error occurs
+  with a single `Exception` argument for error instance.
 * `close`: Emitted whenever the connection is closed.
-* `pipe`: Emitted whenever a readable stream is `pipe()`d into this stream.
+* `pipe`: Emitted whenever a readable stream is `pipe()`d into this stream
+  with a single `ReadableStreamInterface` argument for source stream.
 
 ### Methods
 

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -117,7 +117,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
                 );
             }
 
-            $this->emit('error', array(new \RuntimeException('Unable to write to stream: ' . $error->getMessage(), 0, $error), $this));
+            $this->emit('error', array(new \RuntimeException('Unable to write to stream: ' . $error->getMessage(), 0, $error)));
             $this->close();
 
             return;
@@ -128,7 +128,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
 
         // buffer has been above limit and is now below limit
         if ($exceeded && !isset($this->data[$this->softLimit - 1])) {
-            $this->emit('drain', array($this));
+            $this->emit('drain');
         }
 
         // buffer is now completely empty => stop trying to write

--- a/src/ReadableStream.php
+++ b/src/ReadableStream.php
@@ -35,8 +35,8 @@ class ReadableStream extends EventEmitter implements ReadableStreamInterface
         }
 
         $this->closed = true;
-        $this->emit('end', array($this));
-        $this->emit('close', array($this));
+        $this->emit('end');
+        $this->emit('close');
         $this->removeAllListeners();
     }
 }

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -5,9 +5,9 @@ namespace React\Stream;
 use Evenement\EventEmitterInterface;
 
 /**
- * @event data
+ * @event data with single mixed argument for incoming data
  * @event end
- * @event error
+ * @event error with single Exception argument for error instance
  * @event close
  */
 interface ReadableStreamInterface extends EventEmitterInterface

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -5,9 +5,9 @@ namespace React\Stream;
 use Evenement\EventEmitterInterface;
 
 /**
- * @event data with single mixed argument for incoming data
+ * @event data with a single mixed argument for incoming data
  * @event end
- * @event error with single Exception argument for error instance
+ * @event error with a single Exception argument for error instance
  * @event close
  */
 interface ReadableStreamInterface extends EventEmitterInterface

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -62,13 +62,13 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $that = $this;
 
         $this->buffer->on('error', function ($error) use ($that) {
-            $that->emit('error', array($error, $that));
+            $that->emit('error', array($error));
         });
 
         $this->buffer->on('close', array($this, 'close'));
 
         $this->buffer->on('drain', function () use ($that) {
-            $that->emit('drain', array($that));
+            $that->emit('drain');
         });
 
         $this->resume();
@@ -116,8 +116,8 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $this->readable = false;
         $this->writable = false;
 
-        $this->emit('end', array($this));
-        $this->emit('close', array($this));
+        $this->emit('end');
+        $this->emit('close');
         $this->loop->removeStream($this->stream);
         $this->buffer->close();
         $this->removeAllListeners();
@@ -164,13 +164,13 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         restore_error_handler();
 
         if ($error !== null) {
-            $this->emit('error', array(new \RuntimeException('Unable to read from stream: ' . $error->getMessage(), 0, $error), $this));
+            $this->emit('error', array(new \RuntimeException('Unable to read from stream: ' . $error->getMessage(), 0, $error)));
             $this->close();
             return;
         }
 
         if ($data !== '') {
-            $this->emit('data', array($data, $this));
+            $this->emit('data', array($data));
         }
 
         if (!is_resource($stream) || feof($stream)) {

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -19,13 +19,13 @@ class ThroughStream extends CompositeStream
 
     public function write($data)
     {
-        $this->readable->emit('data', array($this->filter($data), $this));
+        $this->readable->emit('data', array($this->filter($data)));
     }
 
     public function end($data = null)
     {
         if (null !== $data) {
-            $this->readable->emit('data', array($this->filter($data), $this));
+            $this->readable->emit('data', array($this->filter($data)));
         }
 
         $this->writable->end($data);

--- a/src/WritableStream.php
+++ b/src/WritableStream.php
@@ -33,8 +33,8 @@ class WritableStream extends EventEmitter implements WritableStreamInterface
         }
 
         $this->closed = true;
-        $this->emit('end', array($this));
-        $this->emit('close', array($this));
+        $this->emit('end');
+        $this->emit('close');
         $this->removeAllListeners();
     }
 }

--- a/src/WritableStreamInterface.php
+++ b/src/WritableStreamInterface.php
@@ -6,9 +6,9 @@ use Evenement\EventEmitterInterface;
 
 /**
  * @event drain
- * @event error
+ * @event error with single Exeption argument for error instance
  * @event close
- * @event pipe
+ * @event pipe with single ReadableStreamInterface argument for source stream
  */
 interface WritableStreamInterface extends EventEmitterInterface
 {

--- a/src/WritableStreamInterface.php
+++ b/src/WritableStreamInterface.php
@@ -6,9 +6,9 @@ use Evenement\EventEmitterInterface;
 
 /**
  * @event drain
- * @event error with single Exeption argument for error instance
+ * @event error with a single Exeption argument for error instance
  * @event close
- * @event pipe with single ReadableStreamInterface argument for source stream
+ * @event pipe with a single ReadableStreamInterface argument for source stream
  */
 interface WritableStreamInterface extends EventEmitterInterface
 {

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -186,7 +186,7 @@ class BufferTest extends TestCase
         $buffer->softLimit = 2;
         $buffer->on('error', $this->expectCallableNever());
 
-        $buffer->once('drain', function ($buffer) {
+        $buffer->once('drain', function () use ($buffer) {
             $buffer->listening = false;
             $buffer->write("bar\n");
         });

--- a/tests/StreamIntegrationTest.php
+++ b/tests/StreamIntegrationTest.php
@@ -40,7 +40,7 @@ class StreamIntegrationTest extends TestCase
         $testString = str_repeat("*", $streamA->bufferSize + 1);
 
         $buffer = "";
-        $streamB->on('data', function ($data, $streamB) use (&$buffer, &$testString) {
+        $streamB->on('data', function ($data) use (&$buffer) {
             $buffer .= $data;
         });
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -166,7 +166,7 @@ class StreamTest extends TestCase
     }
 
     public function testEndedStreamsShouldNotWrite()
-    {   
+    {
         $file = tempnam(sys_get_temp_dir(), 'reactphptest_');
         $stream = fopen($file, 'r+');
         $loop = $this->createWriteableLoopMock();
@@ -208,8 +208,8 @@ class StreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new Stream($stream, $loop);
-        $conn->on('data', function ($data, $stream) {
-            $stream->close();
+        $conn->on('data', function ($data) use ($conn) {
+            $conn->close();
         });
 
         fwrite($stream, "foobar\n");


### PR DESCRIPTION
This simple PR changes it so that we only emit event arguments that are actually part of the event, i.e. we no longer emit the instance this event was emitted on. This was actually an undocumented feature, so some component may have relied on this.

Among others, this fixes several issues because these instance where never emitted consistently in the first place. In particular, the `forwardEvents` helper is used throughout React's ecosystem and has never actually updated the instances, as it has never checked any of the event arguments.

I've updated the documentation to now explicitly state which arguments are actually passed to the event handlers.

Not passing these unneeded instances also helps with improving performance slightly. On my system, the benchmark examples went from ~1980 MiB/s to ~2020 MiB/s.

In case the instance the event was emitted on is needed, use a closure and pass it in manually.

Note that this is potentially a BC break in case anybody relied on the undocumented event arguments.