### PR TITLE
Consistent end event semantics (EOF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,19 @@ This component depends on `événement`, which is an implementation of the
 
 * `data`: Emitted whenever data was read from the source
   with a single mixed argument for incoming data.
-* `end`: Emitted when the source has reached the `eof`.
+* `end`: Emitted when the source has successfully reached the end
+  of the stream (EOF).
+  This event will only be emitted if the *end* was reached successfully, not
+  if the stream was interrupted due to an error or explicitly closed.
+  Also note that not all streams know the concept of a "successful end".
 * `error`: Emitted when an error occurs
   with a single `Exception` argument for error instance.
-* `close`: Emitted when the connection is closed.
+* `close`: Emitted when the stream is closed.
 
 ### Methods
 
 * `isReadable()`: Check if the stream is still in a state allowing it to be
-  read from. It becomes unreadable when the connection ends, closes or an
+  read from. It becomes unreadable when the stream ends, closes or an
   error occurs.
 * `pause()`: Remove the data source file descriptor from the event loop. This
   allows you to throttle incoming data.
@@ -46,7 +50,7 @@ This component depends on `événement`, which is an implementation of the
   to accept more data.
 * `error`: Emitted whenever an error occurs
   with a single `Exception` argument for error instance.
-* `close`: Emitted whenever the connection is closed.
+* `close`: Emitted whenever the stream is closed.
 * `pipe`: Emitted whenever a readable stream is `pipe()`d into this stream
   with a single `ReadableStreamInterface` argument for source stream.
 

--- a/src/BufferedSink.php
+++ b/src/BufferedSink.php
@@ -21,6 +21,7 @@ class BufferedSink extends WritableStream implements PromisorInterface
     public function handlePipeEvent($source)
     {
         Util::forwardEvents($source, $this, array('error'));
+        $source->on('close', array($this, 'close'));
     }
 
     public function handleErrorEvent($e)

--- a/src/ReadableStream.php
+++ b/src/ReadableStream.php
@@ -35,7 +35,6 @@ class ReadableStream extends EventEmitter implements ReadableStreamInterface
         }
 
         $this->closed = true;
-        $this->emit('end');
         $this->emit('close');
         $this->removeAllListeners();
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -116,7 +116,6 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         $this->readable = false;
         $this->writable = false;
 
-        $this->emit('end');
         $this->emit('close');
         $this->loop->removeStream($this->stream);
         $this->buffer->close();
@@ -171,10 +170,10 @@ class Stream extends EventEmitter implements DuplexStreamInterface
 
         if ($data !== '') {
             $this->emit('data', array($data));
-        }
-
-        if (!is_resource($stream) || feof($stream)) {
-            $this->end();
+        } else{
+            // no data read => we reached the end and close the stream
+            $this->emit('end');
+            $this->close();
         }
     }
 

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -28,6 +28,8 @@ class ThroughStream extends CompositeStream
             $this->readable->emit('data', array($this->filter($data)));
         }
 
-        $this->writable->end($data);
+        $this->readable->emit('end');
+
+        $this->writable->end();
     }
 }

--- a/src/WritableStream.php
+++ b/src/WritableStream.php
@@ -33,7 +33,6 @@ class WritableStream extends EventEmitter implements WritableStreamInterface
         }
 
         $this->closed = true;
-        $this->emit('end');
         $this->emit('close');
         $this->removeAllListeners();
     }

--- a/tests/ReadableStreamTest.php
+++ b/tests/ReadableStreamTest.php
@@ -37,6 +37,16 @@ class ReadableStreamTest extends TestCase
     }
 
     /** @test */
+    public function closeShouldEmitCloseEvent()
+    {
+        $readable = new ReadableStream();
+        $readable->on('close', $this->expectCallableOnce());
+        $readable->on('end', $this->expectCallableNever());
+
+        $readable->close();
+    }
+
+    /** @test */
     public function doubleCloseShouldWork()
     {
         $readable = new ReadableStream();

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -43,6 +43,20 @@ class StreamTest extends TestCase
         $this->assertSame($buffer, $conn->getBuffer());
     }
 
+    public function testCloseShouldEmitCloseEvent()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $conn = new Stream($stream, $loop);
+        $conn->on('close', $this->expectCallableOnce());
+        $conn->on('end', $this->expectCallableNever());
+
+        $conn->close();
+
+        $this->assertFalse($conn->isReadable());
+    }
+
     /**
      * @covers React\Stream\Stream::__construct
      * @covers React\Stream\Stream::handleData
@@ -114,7 +128,7 @@ class StreamTest extends TestCase
 
         $conn->handleData($stream);
 
-        $this->assertFalse($conn->isReadable());
+        $this->assertTrue($conn->isReadable());
         $this->assertEquals(100000, strlen($capturedData));
     }
 

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -31,6 +31,16 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
+    public function endShouldEmitEndAndClose()
+    {
+        $through = new ThroughStream();
+        $through->on('data', $this->expectCallableNever());
+        $through->on('end', $this->expectCallableOnce());
+        $through->on('close', $this->expectCallableOnce());
+        $through->end();
+    }
+
+    /** @test */
     public function endShouldCloseTheStream()
     {
         $through = new ThroughStream();

--- a/tests/WritableStreamTest.php
+++ b/tests/WritableStreamTest.php
@@ -60,6 +60,16 @@ class WritableStreamTest extends TestCase
     }
 
     /** @test */
+    public function closeShouldEmitCloseEvent()
+    {
+        $through = new WritableStream();
+        $through->on('close', $this->expectCallableOnce());
+        $through->on('end', $this->expectCallableNever());
+
+        $through->close();
+    }
+
+    /** @test */
     public function doubleCloseShouldWork()
     {
         $through = new WritableStream();


### PR DESCRIPTION
An `end` event will (only) be emitted when the stream/connection reached EOF (end of file or other side closes the connection)

This is potentially a BC break for anybody who relied on the existing inconsistent(!) behavior, where the `end` was usually(!) emitted right before a `close` event. Consumers should use the unchanged `close` event in this case.

Closes #59