### PR TITLE
Consistent pipe() semantics for closed and closing streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ $source->on('close', function () use ($dest) {
 });
 ```
 
+If the source stream is not readable (closed state), then this is a NO-OP.
+
+```php
+$source->close();
+$source->pipe($dest); // NO-OP
+```
+
+If the destinantion stream is not writable (closed state), then this will simply
+throttle (pause) the source stream:
+
+```php
+$dest->close();
+$source->pipe($dest); // calls $source->pause()
+```
+
 ## Writable Streams
 
 ### EventEmitter Events

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ $dest->close();
 $source->pipe($dest); // calls $source->pause()
 ```
 
+Similarly, if the destination stream is closed while the pipe is still
+active, it will also throttle (pause) the source stream:
+
+```php
+$source->pipe($dest);
+$dest->close(); // calls $source->pause()
+```
+
 ## Writable Streams
 
 ### EventEmitter Events

--- a/README.md
+++ b/README.md
@@ -37,10 +37,40 @@ This component depends on `événement`, which is an implementation of the
 * `pause()`: Remove the data source file descriptor from the event loop. This
   allows you to throttle incoming data.
 * `resume()`: Re-attach the data source after a `pause()`.
-* `pipe(WritableStreamInterface $dest, array $options = [])`: Pipe this
-  readable stream into a writable stream. Automatically sends all incoming
-  data to the destination. Automatically throttles based on what the
-  destination can handle.
+* `pipe(WritableStreamInterface $dest, array $options = [])`:
+Pipe all the data from this readable source into the given writable destination.
+
+Automatically sends all incoming data to the destination.
+Automatically throttles the source based on what the destination can handle.
+
+```php
+$source->pipe($dest);
+```
+
+This method returns the destination stream as-is, which can be used to
+set up chains of piped streams:
+
+```php
+$source->pipe($decodeGzip)->pipe($filterBadWords)->pipe($dest);
+```
+
+By default, this will call `end()` on the destination stream once the
+source stream emits an `end` event. This can be disabled like this:
+
+```php
+$source->pipe($dest, array('end' => false));
+```
+
+Note that this only applies to the `end` event.
+If an `error` or explicit `close` event happens on the source stream,
+you'll have to manually close the destination stream:
+
+```php
+$source->pipe($dest);
+$source->on('close', function () use ($dest) {
+    $dest->end('BYE!');
+});
+```
 
 ## Writable Streams
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Automatically throttles the source based on what the destination can handle.
 $source->pipe($dest);
 ```
 
+Similarly, you can also pipe an instance implementing `DuplexStreamInterface`
+into itself in order to write back all the data that is received.
+This may be a useful feature for a TCP/IP echo service:
+
+```php
+$connection->pipe($connection);
+```
+
 This method returns the destination stream as-is, which can be used to
 set up chains of piped streams:
 

--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -55,9 +55,7 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
 
     public function pipe(WritableStreamInterface $dest, array $options = array())
     {
-        Util::pipe($this, $dest, $options);
-
-        return $dest;
+        return Util::pipe($this, $dest, $options);
     }
 
     public function isWritable()

--- a/src/ReadableStream.php
+++ b/src/ReadableStream.php
@@ -23,9 +23,7 @@ class ReadableStream extends EventEmitter implements ReadableStreamInterface
 
     public function pipe(WritableStreamInterface $dest, array $options = array())
     {
-        Util::pipe($this, $dest, $options);
-
-        return $dest;
+        return Util::pipe($this, $dest, $options);
     }
 
     public function close()

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -51,6 +51,21 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * });
      * ```
      *
+     * If the source stream is not readable (closed state), then this is a NO-OP.
+     *
+     * ```php
+     * $source->close();
+     * $source->pipe($dest); // NO-OP
+     * ```
+     *
+     * If the destinantion stream is not writable (closed state), then this will simply
+     * throttle (pause) the source stream:
+     *
+     * ```php
+     * $dest->close();
+     * $source->pipe($dest); // calls $source->pause()
+     * ```
+     *
      * @param WritableStreamInterface $dest
      * @param array $options
      * @return WritableStreamInterface $dest stream as-is

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -66,6 +66,14 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * $source->pipe($dest); // calls $source->pause()
      * ```
      *
+     * Similarly, if the destination stream is closed while the pipe is still
+     * active, it will also throttle (pause) the source stream:
+     *
+     * ```php
+     * $source->pipe($dest);
+     * $dest->close(); // calls $source->pause()
+     * ```
+     *
      * @param WritableStreamInterface $dest
      * @param array $options
      * @return WritableStreamInterface $dest stream as-is

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -15,6 +15,47 @@ interface ReadableStreamInterface extends EventEmitterInterface
     public function isReadable();
     public function pause();
     public function resume();
+
+    /**
+     * Pipes all the data from this readable source into the given writable destination.
+     *
+     * Automatically sends all incoming data to the destination.
+     * Automatically throttles the source based on what the destination can handle.
+     *
+     * ```php
+     * $source->pipe($dest);
+     * ```
+     *
+     * This method returns the destination stream as-is, which can be used to
+     * set up chains of piped streams:
+     *
+     * ```php
+     * $source->pipe($decodeGzip)->pipe($filterBadWords)->pipe($dest);
+     * ```
+     *
+     * By default, this will call `end()` on the destination stream once the
+     * source stream emits an `end` event. This can be disabled like this:
+     *
+     * ```php
+     * $source->pipe($dest, array('end' => false));
+     * ```
+     *
+     * Note that this only applies to the `end` event.
+     * If an `error` or explicit `close` event happens on the source stream,
+     * you'll have to manually close the destination stream:
+     *
+     * ```php
+     * $source->pipe($dest);
+     * $source->on('close', function () use ($dest) {
+     *     $dest->end('BYE!');
+     * });
+     * ```
+     *
+     * @param WritableStreamInterface $dest
+     * @param array $options
+     * @return WritableStreamInterface $dest stream as-is
+     */
     public function pipe(WritableStreamInterface $dest, array $options = array());
+
     public function close();
 }

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -26,6 +26,14 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * $source->pipe($dest);
      * ```
      *
+     * Similarly, you can also pipe an instance implementing `DuplexStreamInterface`
+     * into itself in order to write back all the data that is received.
+     * This may be a useful feature for a TCP/IP echo service:
+     *
+     * ```php
+     * $connection->pipe($connection);
+     * ```
+     *
      * This method returns the destination stream as-is, which can be used to
      * set up chains of piped streams:
      *

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -140,9 +140,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
 
     public function pipe(WritableStreamInterface $dest, array $options = array())
     {
-        Util::pipe($this, $dest, $options);
-
-        return $dest;
+        return Util::pipe($this, $dest, $options);
     }
 
     public function handleData($stream)

--- a/src/Util.php
+++ b/src/Util.php
@@ -2,16 +2,19 @@
 
 namespace React\Stream;
 
-// TODO: move to a trait
-
 class Util
 {
+    /**
+     * Pipes all the data from the given $source into the $dest
+     *
+     * @param ReadableStreamInterface $source
+     * @param WritableStreamInterface $dest
+     * @param array $options
+     * @return WritableStreamInterface $dest stream as-is
+     * @see ReadableStreamInterface::pipe() for more details
+     */
     public static function pipe(ReadableStreamInterface $source, WritableStreamInterface $dest, array $options = array())
     {
-        // TODO: use stream_copy_to_stream
-        // it is 4x faster than this
-        // but can lose data under load with no way to recover it
-
         $dest->emit('pipe', array($source));
 
         $source->on('data', function ($data) use ($source, $dest) {
@@ -32,6 +35,8 @@ class Util
                 $dest->end();
             });
         }
+
+        return $dest;
     }
 
     public static function forwardEvents($source, $target, array $events)

--- a/src/Util.php
+++ b/src/Util.php
@@ -15,6 +15,18 @@ class Util
      */
     public static function pipe(ReadableStreamInterface $source, WritableStreamInterface $dest, array $options = array())
     {
+        // source not readable => NO-OP
+        if (!$source->isReadable()) {
+            return $dest;
+        }
+
+        // destination not writable => just pause() source
+        if (!$dest->isWritable()) {
+            $source->pause();
+
+            return $dest;
+        }
+
         $dest->emit('pipe', array($source));
 
         $source->on('data', function ($data) use ($source, $dest) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -52,7 +52,7 @@ class Util
 
         // forward end event from source as $dest->end()
         $end = isset($options['end']) ? $options['end'] : true;
-        if ($end && $source !== $dest) {
+        if ($end) {
             $source->on('end', $ender = function () use ($dest) {
                 $dest->end();
             });

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -112,6 +112,7 @@ class CompositeStreamTest extends TestCase
     {
         $readable = $this->getMock('React\Stream\ReadableStreamInterface');
         $writable = $this->getMock('React\Stream\WritableStreamInterface');
+        $writable->expects($this->any())->method('isWritable')->willReturn(True);
         $writable
             ->expects($this->once())
             ->method('write')
@@ -154,9 +155,11 @@ class CompositeStreamTest extends TestCase
     {
         $readable = new ReadableStream();
         $writable = $this->getMock('React\Stream\WritableStreamInterface');
+        $writable->expects($this->any())->method('isWritable')->willReturn(True);
         $composite = new CompositeStream($readable, $writable);
 
         $output = $this->getMock('React\Stream\WritableStreamInterface');
+        $output->expects($this->any())->method('isWritable')->willReturn(True);
         $output
             ->expects($this->once())
             ->method('write')

--- a/tests/ReadableStreamTest.php
+++ b/tests/ReadableStreamTest.php
@@ -28,6 +28,15 @@ class ReadableStreamTest extends TestCase
     }
 
     /** @test */
+    public function pipeShouldReturnDestination()
+    {
+        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $readable = new ReadableStream();
+
+        $this->assertSame($dest, $readable->pipe($dest));
+    }
+
+    /** @test */
     public function closeShouldClose()
     {
         $readable = new ReadableStream();

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -198,6 +198,17 @@ class StreamTest extends TestCase
         unlink($file);
     }
 
+    public function testPipeShouldReturnDestination()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $conn = new Stream($stream, $loop);
+        $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+
+        $this->assertSame($dest, $conn->pipe($dest));
+    }
+
     public function testBufferEventsShouldBubbleUp()
     {
         $stream = fopen('php://temp', 'r+');

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -135,6 +135,7 @@ class ThroughStreamTest extends TestCase
     public function pipeShouldPipeCorrectly()
     {
         $output = $this->getMock('React\Stream\WritableStreamInterface');
+        $output->expects($this->any())->method('isWritable')->willReturn(True);
         $output
             ->expects($this->once())
             ->method('write')

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -6,6 +6,7 @@ use React\Stream\Buffer;
 use React\Stream\ReadableStream;
 use React\Stream\Util;
 use React\Stream\WritableStream;
+use React\Stream\CompositeStream;
 
 /**
  * @covers React\Stream\Util
@@ -230,6 +231,21 @@ class UtilTest extends TestCase
         $this->assertCount(0, $source->listeners('data'));
         $this->assertCount(0, $source->listeners('end'));
         $this->assertCount(0, $dest->listeners('drain'));
+    }
+
+    public function testPipeDuplexIntoSelfEndsOnEnd()
+    {
+        $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $readable->expects($this->any())->method('isReadable')->willReturn(true);
+        $writable = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $writable->expects($this->any())->method('isWritable')->willReturn(true);
+        $duplex = new CompositeStream($readable, $writable);
+
+        Util::pipe($duplex, $duplex);
+
+        $writable->expects($this->once())->method('end');
+
+        $duplex->emit('end');
     }
 
     /** @test */

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -11,6 +11,17 @@ use React\Stream\Util;
  */
 class UtilTest extends TestCase
 {
+    public function testPipeReturnsDestinationStream()
+    {
+        $readable = $this->getMock('React\Stream\ReadableStreamInterface');
+
+        $writable = $this->getMock('React\Stream\WritableStreamInterface');
+
+        $ret = Util::pipe($readable, $writable);
+
+        $this->assertSame($writable, $ret);
+    }
+
     public function testPipeShouldEmitEvents()
     {
         $readable = $this->getMock('React\Stream\ReadableStreamInterface');


### PR DESCRIPTION
The `pipe()` method previously showed some inconsistent behavior depending on which side of the pipe closed at which time (prior to piping or during piping).

The `pipe()` method now shows consistent behavior of calling `pause()` on the source side if the target is saturated or closed and now cleanly removes the event forwarding if either side is closed.

This should not affect normal usage, but some of the more hidden scenarios may in fact rely on the previous behavior. As such, I'm marking this as a BC break just to be safe.

If you want to review, also consider looking at the individual commits, this should make the changes more obvious.

Fixes / closes #36
Builds on top of #70