### PR TITLE
Obey strict method and event semantics for closed and piped streams

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -99,7 +99,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
     public function write($data)
     {
         if (!$this->writable) {
-            return;
+            return false;
         }
 
         return $this->buffer->write($data);

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -4,6 +4,8 @@ namespace React\Stream;
 
 class ThroughStream extends CompositeStream
 {
+    private $paused = false;
+
     public function __construct()
     {
         $readable = new ReadableStream();
@@ -17,6 +19,18 @@ class ThroughStream extends CompositeStream
         return $data;
     }
 
+    public function pause()
+    {
+        parent::pause();
+        $this->paused = true;
+    }
+
+    public function resume()
+    {
+        parent::resume();
+        $this->paused = false;
+    }
+
     public function write($data)
     {
         if (!$this->writable->isWritable()) {
@@ -25,7 +39,7 @@ class ThroughStream extends CompositeStream
 
         $this->readable->emit('data', array($this->filter($data)));
 
-        return $this->writable->isWritable();
+        return $this->writable->isWritable() && !$this->paused;
     }
 
     public function end($data = null)

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -19,17 +19,21 @@ class ThroughStream extends CompositeStream
 
     public function write($data)
     {
-        if (!$this->writable) {
+        if (!$this->writable->isWritable()) {
             return false;
         }
 
         $this->readable->emit('data', array($this->filter($data)));
 
-        return true;
+        return $this->writable->isWritable();
     }
 
     public function end($data = null)
     {
+        if (!$this->writable->isWritable()) {
+            return;
+        }
+
         if (null !== $data) {
             $this->readable->emit('data', array($this->filter($data)));
         }

--- a/tests/BufferedSinkTest.php
+++ b/tests/BufferedSinkTest.php
@@ -134,6 +134,15 @@ class BufferedSinkTest extends TestCase
     }
 
     /** @test */
+    public function writeAfterEndShouldReturnFalse()
+    {
+        $sink = new BufferedSink();
+        $sink->end();
+
+        $this->assertFalse($sink->write('foo'));
+    }
+
+    /** @test */
     public function forwardedErrorsFromPipeShouldRejectPromise()
     {
         $errback = $this->expectCallableOnceWith($this->callback(function ($e) {

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -126,6 +126,44 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
+    public function itShouldForwardPauseUpstreamWhenPipedTo()
+    {
+        $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $readable->expects($this->any())->method('isReadable')->willReturn(true);
+        $writable = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $writable->expects($this->any())->method('isWritable')->willReturn(true);
+
+        $composite = new CompositeStream($readable, $writable);
+
+        $input = $this->getMockBuilder('React\Stream\ReadableStream')->setMethods(array('pause', 'resume'))->getMock();
+        $input
+            ->expects($this->once())
+            ->method('pause');
+
+        $input->pipe($composite);
+        $composite->pause();
+    }
+
+    /** @test */
+    public function itShouldForwardResumeUpstreamWhenPipedTo()
+    {
+        $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $readable->expects($this->any())->method('isReadable')->willReturn(true);
+        $writable = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $writable->expects($this->any())->method('isWritable')->willReturn(true);
+
+        $composite = new CompositeStream($readable, $writable);
+
+        $input = $this->getMockBuilder('React\Stream\ReadableStream')->setMethods(array('pause', 'resume'))->getMock();
+        $input
+            ->expects($this->once())
+            ->method('resume');
+
+        $input->pipe($composite);
+        $composite->resume();
+    }
+
+    /** @test */
     public function itShouldForwardPauseAndResumeUpstreamWhenPipedTo()
     {
         $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -57,6 +57,32 @@ class StreamTest extends TestCase
         $this->assertFalse($conn->isReadable());
     }
 
+    public function testEndShouldEndBuffer()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $buffer->expects($this->once())->method('end')->with('foo');
+
+        $conn = new Stream($stream, $loop, $buffer);
+        $conn->end('foo');
+    }
+
+
+    public function testEndAfterCloseIsNoOp()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+
+        $buffer = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $buffer->expects($this->never())->method('end');
+
+        $conn = new Stream($stream, $loop);
+        $conn->close();
+        $conn->end();
+    }
+
     /**
      * @covers React\Stream\Stream::__construct
      * @covers React\Stream\Stream::handleData
@@ -193,7 +219,7 @@ class StreamTest extends TestCase
         $stream = fopen($file, 'r');
 
         $this->assertSame("foo\n", fgets($stream));
-        $this->assertNull($res);
+        $this->assertFalse($res);
 
         unlink($file);
     }

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -63,6 +63,34 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
+    public function endTwiceShouldOnlyEmitOnce()
+    {
+        $through = new ThroughStream();
+        $through->on('data', $this->expectCallableOnce('first'));
+        $through->end('first');
+        $through->end('ignored');
+    }
+
+    /** @test */
+    public function writeAfterEndShouldReturnFalse()
+    {
+        $through = new ThroughStream();
+        $through->on('data', $this->expectCallableNever());
+        $through->end();
+
+        $this->assertFalse($through->write('foo'));
+    }
+
+    /** @test */
+    public function writeDataWillCloseStreamShouldReturnFalse()
+    {
+        $through = new ThroughStream();
+        $through->on('data', array($through, 'close'));
+
+        $this->assertFalse($through->write('foo'));
+    }
+
+    /** @test */
     public function itShouldBeReadableByDefault()
     {
         $through = new ThroughStream();

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -91,6 +91,25 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
+    public function writeDataToPausedShouldReturnFalse()
+    {
+        $through = new ThroughStream();
+        $through->pause();
+
+        $this->assertFalse($through->write('foo'));
+    }
+
+    /** @test */
+    public function writeDataToResumedShouldReturnTrue()
+    {
+        $through = new ThroughStream();
+        $through->pause();
+        $through->resume();
+
+        $this->assertTrue($through->write('foo'));
+    }
+
+    /** @test */
     public function itShouldBeReadableByDefault()
     {
         $through = new ThroughStream();


### PR DESCRIPTION
Builds on top of #72 and #73 and makes sure all methods obey strict method and event semantics for some of the less obvious cases. This project now has 100% test coverage :tada:  