### PR TITLE
Fix composer keyword (I/O -> io)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "react/stream",
     "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
-    "keywords": ["event-driven", "readable", "writable", "stream", "non-blocking", "I/O", "pipe", "ReactPHP"],
+    "keywords": ["event-driven", "readable", "writable", "stream", "non-blocking", "io", "pipe", "ReactPHP"],
     "license": "MIT",
     "require": {
         "php": ">=5.3.8",


### PR DESCRIPTION
```bash
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
keywords.5 : invalid value (I/O), must match [\p{N}\p{L} ._-]+
```