### PR TITLE
Do not use unbuffered reads on pipe streams for legacy PHP < 5.4

### DIFF
--- a/examples/cat.php
+++ b/examples/cat.php
@@ -1,0 +1,16 @@
+<?php
+
+use React\EventLoop\Factory;
+use React\Stream\Stream;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = Factory::create();
+
+$stdout = new Stream(STDOUT, $loop);
+$stdout->pause();
+
+$stdin = new Stream(STDIN, $loop);
+$stdin->pipe($stdout);
+
+$loop->run();


### PR DESCRIPTION
Currently, reading from a pipe stream (such as STDIN) causes SEGFAULTs on legacy PHP < 5.4.

I've added a very simple `cat.php` example which highlights this issue.

This patch avoids switching to unbuffered mode for pipe streams on PHP < 5.4 and thus avoids this issue on all versions. Technically, unbuffered reads aren't really needed here for any PHP version, but not using unbuffered reads shows a 10%-20% performance penalty.

Fixes #78 