### PR TITLE
Add WritableResourceStream

### DIFF
--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -23,8 +23,7 @@ $info->write('piping from ' . $if . ' to ' . $of . ' (for max ' . $t . ' second(
 
 // setup input and output streams and pipe inbetween
 $in = new React\Stream\ReadableResourceStream(fopen($if, 'r'), $loop);
-$out = new React\Stream\Stream(fopen($of, 'w'), $loop);
-$out->pause();
+$out = new React\Stream\WritableResourceStream(fopen($of, 'w'), $loop);
 $in->pipe($out);
 
 // stop input stream in $t seconds

--- a/examples/cat.php
+++ b/examples/cat.php
@@ -1,16 +1,14 @@
 <?php
 
 use React\EventLoop\Factory;
-use React\Stream\Stream;
 use React\Stream\ReadableResourceStream;
+use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = Factory::create();
 
-$stdout = new Stream(STDOUT, $loop);
-$stdout->pause();
-
+$stdout = new WritableResourceStream(STDOUT, $loop);
 $stdin = new ReadableResourceStream(STDIN, $loop);
 $stdin->pipe($stdout);
 

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -44,7 +44,7 @@ class ReadableResourceStream extends EventEmitter implements ReadableStreamInter
 
         // ensure resource is opened for reading (fopen mode must contain "r" or "+")
         $meta = stream_get_meta_data($stream);
-        if (isset($meta['mode']) && strpos($meta['mode'], 'r') === strpos($meta['mode'], '+')) {
+        if (isset($meta['mode']) && $meta['mode'] !== '' && strpos($meta['mode'], 'r') === strpos($meta['mode'], '+')) {
             throw new InvalidArgumentException('Given stream resource is not opened in read mode');
         }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -58,7 +58,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
         }
 
         if ($buffer === null) {
-            $buffer = new Buffer($stream, $loop);
+            $buffer = new WritableResourceStream($stream, $loop);
         }
 
         $this->stream = $stream;
@@ -189,7 +189,7 @@ class Stream extends EventEmitter implements DuplexStreamInterface
     }
 
     /**
-     * @return WritableStreamInterface|Buffer
+     * @return WritableStreamInterface
      */
     public function getBuffer()
     {

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -5,11 +5,12 @@ namespace React\Stream;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 
-class Buffer extends EventEmitter implements WritableStreamInterface
+class WritableResourceStream extends EventEmitter implements WritableStreamInterface
 {
     public $stream;
-    public $listening = false;
     public $softLimit = 65536;
+
+    private $listening = false;
     private $writable = true;
     private $closed = false;
     private $loop;
@@ -87,6 +88,7 @@ class Buffer extends EventEmitter implements WritableStreamInterface
         $this->removeAllListeners();
     }
 
+    /** @internal */
     public function handleWrite()
     {
         $error = null;

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -22,6 +22,11 @@ class WritableResourceStream extends EventEmitter implements WritableStreamInter
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
+        $meta = stream_get_meta_data($stream);
+        if (isset($meta['mode']) && str_replace(array('b', 't'), '', $meta['mode']) === 'r') {
+            throw new \InvalidArgumentException('Given stream resource is not opened in write mode');
+        }
+
         // this class relies on non-blocking I/O in order to not interrupt the event loop
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
         if (stream_set_blocking($stream, 0) !== true) {

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -34,6 +34,10 @@ class ReadableResourceStreamTest extends TestCase
      */
     public function testConstructorThrowsExceptionOnWriteOnlyStream()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM does not report fopen mode for STDOUT');
+        }
+
         $loop = $this->createLoopMock();
 
         $this->setExpectedException('InvalidArgumentException');

--- a/tests/StreamIntegrationTest.php
+++ b/tests/StreamIntegrationTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Stream;
 
 use React\Stream\Stream;
 use React\EventLoop as rel;
+use React\Stream\ReadableResourceStream;
 
 class StreamIntegrationTest extends TestCase
 {
@@ -231,7 +232,7 @@ class StreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new Stream(popen('echo test', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('echo test', 'r'), $loop);
         $stream->on('data', $this->expectCallableOnceWith("test\n"));
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
@@ -250,7 +251,7 @@ class StreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new Stream(popen('echo -n a;sleep 0.1;echo -n b;sleep 0.1;echo -n c', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('echo -n a;sleep 0.1;echo -n b;sleep 0.1;echo -n c', 'r'), $loop);
 
         $buffer = '';
         $stream->on('data', function ($chunk) use (&$buffer) {
@@ -276,7 +277,7 @@ class StreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new Stream(popen('dd if=/dev/zero bs=12345 count=1234 2>&-', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('dd if=/dev/zero bs=12345 count=1234 2>&-', 'r'), $loop);
 
         $bytes = 0;
         $stream->on('data', function ($chunk) use (&$bytes) {
@@ -302,7 +303,7 @@ class StreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new Stream(popen('true', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('true', 'r'), $loop);
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -2,7 +2,7 @@
 
 namespace React\Tests\Stream;
 
-use React\Stream\Buffer;
+use React\Stream\WritableResourceStream;
 use React\Stream\ReadableStream;
 use React\Stream\Util;
 use React\Stream\WritableStream;
@@ -171,13 +171,13 @@ class UtilTest extends TestCase
         $this->assertFalse($readable->paused);
     }
 
-    public function testPipeWithBuffer()
+    public function testPipeWithWritableResourceStream()
     {
         $readable = new Stub\ReadableStreamStub();
 
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
-        $buffer = new Buffer($stream, $loop);
+        $buffer = new WritableResourceStream($stream, $loop);
 
         $readable->pipe($buffer);
 

--- a/tests/WritableStreamResourceTest.php
+++ b/tests/WritableStreamResourceTest.php
@@ -32,6 +32,18 @@ class WritableResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\WritableResourceStream::__construct
+     * @expectedException InvalidArgumentException
+     */
+    public function testConstructorThrowsExceptionOnReadOnlyStream()
+    {
+        $stream = fopen('php://temp', 'r');
+        $loop = $this->createLoopMock();
+
+        new WritableResourceStream($stream, $loop);
+    }
+
+    /**
+     * @covers React\Stream\WritableResourceStream::__construct
      */
     public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
     {
@@ -137,10 +149,14 @@ class WritableResourceStreamTest extends TestCase
             $this->markTestSkipped('HHVM allows writing to read-only memory streams');
         }
 
-        $stream = fopen('php://temp', 'r');
+        $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
+
+        // nasty hack to replace with reaad-only stream resource
+        $buffer->stream = fopen('php://temp', 'r');
+
         $buffer->on('error', $this->expectCallableOnce());
         //$buffer->on('close', $this->expectCallableOnce());
 


### PR DESCRIPTION
The old `Buffer` has been renamed to `WritableResourceStream` to complement the `ReadableResourceStream` introduced via #83.

Note that the `WritableResourceStream` now rejects read-only streams, so this may affect BC. If you want a read-only resource, use `ReadableResourceStream` instead of `Stream`.

Refs #37 and builds on top of #83.