### PR TITLE
Add DuplexResourceStream and deprecate Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,9 @@ Otherwise, it will throw an `InvalidArgumentException`:
 $stream = new ReadableResourceStream(false, $loop);
 ```
 
+See also the [`DuplexResourceStream`](#readableresourcestream) for read-and-write
+stream resources otherwise.
+
 Internally, this class tries to enable non-blocking mode on the stream resource
 which may not be supported for all stream resources.
 Most notably, this is not supported by pipes on Windows (STDIN etc.).
@@ -788,6 +791,9 @@ Otherwise, it will throw an `InvalidArgumentException`:
 $stream = new WritableResourceStream(false, $loop);
 ```
 
+See also the [`DuplexResourceStream`](#readableresourcestream) for read-and-write
+stream resources otherwise.
+
 Internally, this class tries to enable non-blocking mode on the stream resource
 which may not be supported for all stream resources.
 Most notably, this is not supported by pipes on Windows (STDOUT, STDERR etc.).
@@ -841,13 +847,18 @@ $stream->end();
 
 See also [`DuplexStreamInterface`](#duplexstreaminterface) for more details.
 
-The first parameter given to the constructor MUST be a valid stream resource.
+The first parameter given to the constructor MUST be a valid stream resource
+that is opened for reading *and* writing.
 Otherwise, it will throw an `InvalidArgumentException`:
 
 ```php
 // throws InvalidArgumentException
 $stream = new DuplexResourceStream(false, $loop);
 ```
+
+See also the [`ReadableResourceStream`](#readableresourcestream) for read-only
+and the [`WritableResourceStream`](#writableresourcestream) for write-only
+stream resources otherwise.
 
 Internally, this class tries to enable non-blocking mode on the stream resource
 which may not be supported for all stream resources.

--- a/README.md
+++ b/README.md
@@ -914,6 +914,10 @@ $buffer->softLimit = 8192;
 
 See also [`write()`](#write) for more details.
 
+> BC note: This class was previously called `Stream`.
+  The `Stream` class still exists for BC reasons and will be removed in future
+  versions of this package.
+
 ## Usage
 ```php
     $loop = React\EventLoop\Factory::create();

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ descriptor based implementation with an in-memory write buffer.
   * [DuplexStreamInterface](#duplexstreaminterface)
   * [ReadableResourceStream](#readableresourcestream)
   * [WritableResourceStream](#writableresourcestream)
+  * [DuplexResourceStream](#duplexresourcestream)
 * [Usage](#usage)
 * [Install](#install)
 * [Tests](#tests)
@@ -819,6 +820,85 @@ It currently defaults to 64 KiB and can be controlled through the public
 
 ```php
 $stream->softLimit = 8192;
+```
+
+See also [`write()`](#write) for more details.
+
+### DuplexResourceStream
+
+The `DuplexResourceStream` is a concrete implementation of the
+[`DuplexStreamInterface`](#duplexstreaminterface) for PHP's stream resources.
+
+This can be used to represent a read-and-write resource like a file stream opened
+in read and write mode mode or a stream such as a TCP/IP connection:
+
+```php
+$conn = stream_socket_client('tcp://google.com:80');
+$stream = new DuplexResourceStream($conn, $loop);
+$stream->write('hello!');
+$stream->end();
+```
+
+See also [`DuplexStreamInterface`](#duplexstreaminterface) for more details.
+
+The first parameter given to the constructor MUST be a valid stream resource.
+Otherwise, it will throw an `InvalidArgumentException`:
+
+```php
+// throws InvalidArgumentException
+$stream = new DuplexResourceStream(false, $loop);
+```
+
+Internally, this class tries to enable non-blocking mode on the stream resource
+which may not be supported for all stream resources.
+Most notably, this is not supported by pipes on Windows (STDOUT, STDERR etc.).
+If this fails, it will throw a `RuntimeException`:
+
+```php
+// throws RuntimeException on Windows
+$stream = new DuplexResourceStream(STDOUT, $loop);
+```
+
+Once the constructor is called with a valid stream resource, this class will
+take care of the underlying stream resource.
+You SHOULD only use its public API and SHOULD NOT interfere with the underlying
+stream resource manually.
+Should you need to access the underlying stream resource, you can use the public
+`$stream` property like this:
+
+```php
+var_dump(stream_get_meta_data($stream->stream));
+```
+
+The `$bufferSize` property controls the maximum buffer size in bytes to read
+at once from the stream.
+This value SHOULD NOT be changed unless you know what you're doing.
+This can be a positive number which means that up to X bytes will be read
+at once from the underlying stream resource. Note that the actual number
+of bytes read may be lower if the stream resource has less than X bytes
+currently available.
+This can be `null` which means "read everything available" from the
+underlying stream resource.
+This should read until the stream resource is not readable anymore
+(i.e. underlying buffer drained), note that this does not neccessarily
+mean it reached EOF.
+
+```php
+$stream->bufferSize = 8192;
+```
+
+Any `write()` calls to this class will not be performaned instantly, but will
+be performaned asynchronously, once the EventLoop reports the stream resource is
+ready to accept data.
+For this, it uses an in-memory buffer string to collect all outstanding writes.
+This buffer has a soft-limit applied which defines how much data it is willing
+to accept before the caller SHOULD stop sending further data.
+It currently defaults to 64 KiB and can be controlled through the public
+`$softLimit` property like this:
+
+```php
+$buffer = $stream->getBuffer();
+$buffer->softLimit = 8192;
 ```
 
 See also [`write()`](#write) for more details.

--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -14,7 +14,7 @@ $of = str_replace('/dev/fd/', 'php://fd/', $of);
 $loop = new React\EventLoop\StreamSelectLoop();
 
 // setup information stream
-$info = new React\Stream\Stream(STDERR, $loop);
+$info = new React\Stream\DuplexResourceStream(STDERR, $loop);
 $info->pause();
 if (extension_loaded('xdebug')) {
     $info->write('NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL);

--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -14,8 +14,7 @@ $of = str_replace('/dev/fd/', 'php://fd/', $of);
 $loop = new React\EventLoop\StreamSelectLoop();
 
 // setup information stream
-$info = new React\Stream\DuplexResourceStream(STDERR, $loop);
-$info->pause();
+$info = new React\Stream\WritableResourceStream(STDERR, $loop);
 if (extension_loaded('xdebug')) {
     $info->write('NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL);
 }

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -6,10 +6,10 @@ use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use InvalidArgumentException;
 
-class Stream extends EventEmitter implements DuplexStreamInterface
+class DuplexResourceStream extends EventEmitter implements DuplexStreamInterface
 {
     /**
-     * Controls the maximum buffer size in bytes to ready at once from the stream.
+     * Controls the maximum buffer size in bytes to read at once from the stream.
      *
      * This can be a positive number which means that up to X bytes will be read
      * at once from the underlying stream resource. Note that the actual number

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -39,6 +39,12 @@ class DuplexResourceStream extends EventEmitter implements DuplexStreamInterface
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
+        // ensure resource is opened for reading and wrting (fopen mode must contain "+")
+        $meta = stream_get_meta_data($stream);
+        if (isset($meta['mode']) && $meta['mode'] !== '' && strpos($meta['mode'], '+') === false) {
+            throw new InvalidArgumentException('Given stream resource is not opened in read and write mode');
+        }
+
         // this class relies on non-blocking I/O in order to not interrupt the event loop
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
         if (stream_set_blocking($stream, 0) !== true) {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace React\Stream;
+
+/**
+ * @deprecated in favor of DuplexResourceStream
+ * @see DuplexResourceStream
+ */
+class Stream extends DuplexResourceStream
+{
+}

--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -2,11 +2,11 @@
 
 namespace React\Tests\Stream;
 
-use React\Stream\Stream;
+use React\Stream\DuplexResourceStream;
 use React\EventLoop as rel;
 use React\Stream\ReadableResourceStream;
 
-class StreamIntegrationTest extends TestCase
+class DuplexResourceStreamIntegrationTest extends TestCase
 {
     public function loopProvider()
     {
@@ -31,8 +31,8 @@ class StreamIntegrationTest extends TestCase
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
-        $streamA = new Stream($sockA, $loop);
-        $streamB = new Stream($sockB, $loop);
+        $streamA = new DuplexResourceStream($sockA, $loop);
+        $streamB = new DuplexResourceStream($sockB, $loop);
 
         $bufferSize = 4096;
         $streamA->bufferSize = $bufferSize;
@@ -70,8 +70,8 @@ class StreamIntegrationTest extends TestCase
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
-        $streamA = new Stream($sockA, $loop);
-        $streamB = new Stream($sockB, $loop);
+        $streamA = new DuplexResourceStream($sockA, $loop);
+        $streamB = new DuplexResourceStream($sockB, $loop);
 
         // limit seems to be 192 KiB
         $size = 256 * 1024;
@@ -110,8 +110,8 @@ class StreamIntegrationTest extends TestCase
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
-        $streamA = new Stream($sockA, $loop);
-        $streamB = new Stream($sockB, $loop);
+        $streamA = new DuplexResourceStream($sockA, $loop);
+        $streamB = new DuplexResourceStream($sockB, $loop);
 
         // end streamA without writing any data
         $streamA->end();
@@ -138,8 +138,8 @@ class StreamIntegrationTest extends TestCase
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
-        $streamA = new Stream($sockA, $loop);
-        $streamB = new Stream($sockB, $loop);
+        $streamA = new DuplexResourceStream($sockA, $loop);
+        $streamB = new DuplexResourceStream($sockB, $loop);
 
         // end streamA without writing any data
         $streamA->pause();
@@ -171,8 +171,8 @@ class StreamIntegrationTest extends TestCase
         $client = stream_socket_client(stream_socket_get_name($server, false));
         $peer = stream_socket_accept($server);
 
-        $streamA = new Stream($client, $loop);
-        $streamB = new Stream($peer, $loop);
+        $streamA = new DuplexResourceStream($client, $loop);
+        $streamB = new DuplexResourceStream($peer, $loop);
 
         // end streamA without writing any data
         $streamA->pause();
@@ -204,8 +204,8 @@ class StreamIntegrationTest extends TestCase
         $client = stream_socket_client(stream_socket_get_name($server, false));
         $peer = stream_socket_accept($server);
 
-        $streamA = new Stream($peer, $loop);
-        $streamB = new Stream($client, $loop);
+        $streamA = new DuplexResourceStream($peer, $loop);
+        $streamB = new DuplexResourceStream($client, $loop);
 
         // end streamA without writing any data
         $streamA->pause();

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -32,6 +32,21 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      */
+    public function testConstructorThrowsExceptionOnWriteOnlyStream()
+    {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM does not report fopen mode for STDOUT');
+        }
+
+        $loop = $this->createLoopMock();
+
+        $this->setExpectedException('InvalidArgumentException');
+        new DuplexResourceStream(STDOUT, $loop);
+    }
+
+    /**
+     * @covers React\Stream\DuplexResourceStream::__construct
+     */
     public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
     {
         if (!in_array('blocking', stream_get_wrappers())) {

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -2,35 +2,35 @@
 
 namespace React\Tests\Stream;
 
-use React\Stream\Stream;
+use React\Stream\DuplexResourceStream;
 use Clue\StreamFilter as Filter;
 
-class StreamTest extends TestCase
+class DuplexResourceStreamTest extends TestCase
 {
     /**
-     * @covers React\Stream\Stream::__construct
+     * @covers React\Stream\DuplexResourceStream::__construct
      */
     public function testConstructor()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
     }
 
     /**
-     * @covers React\Stream\Stream::__construct
+     * @covers React\Stream\DuplexResourceStream::__construct
      */
     public function testConstructorThrowsExceptionOnInvalidStream()
     {
         $loop = $this->createLoopMock();
 
         $this->setExpectedException('InvalidArgumentException');
-        new Stream('breakme', $loop);
+        new DuplexResourceStream('breakme', $loop);
     }
 
     /**
-     * @covers React\Stream\Stream::__construct
+     * @covers React\Stream\DuplexResourceStream::__construct
      */
     public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
     {
@@ -42,11 +42,11 @@ class StreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $this->setExpectedException('RuntimeException');
-        new Stream($stream, $loop);
+        new DuplexResourceStream($stream, $loop);
     }
 
     /**
-     * @covers React\Stream\Stream::__construct
+     * @covers React\Stream\DuplexResourceStream::__construct
      */
     public function testConstructorAcceptsBuffer()
     {
@@ -55,7 +55,7 @@ class StreamTest extends TestCase
 
         $buffer = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
 
-        $conn = new Stream($stream, $loop, $buffer);
+        $conn = new DuplexResourceStream($stream, $loop, $buffer);
 
         $this->assertSame($buffer, $conn->getBuffer());
     }
@@ -65,7 +65,7 @@ class StreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->on('close', $this->expectCallableOnce());
         $conn->on('end', $this->expectCallableNever());
 
@@ -82,7 +82,7 @@ class StreamTest extends TestCase
         $buffer = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
         $buffer->expects($this->once())->method('end')->with('foo');
 
-        $conn = new Stream($stream, $loop, $buffer);
+        $conn = new DuplexResourceStream($stream, $loop, $buffer);
         $conn->end('foo');
     }
 
@@ -95,14 +95,14 @@ class StreamTest extends TestCase
         $buffer = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
         $buffer->expects($this->never())->method('end');
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->close();
         $conn->end();
     }
 
     /**
-     * @covers React\Stream\Stream::__construct
-     * @covers React\Stream\Stream::handleData
+     * @covers React\Stream\DuplexResourceStream::__construct
+     * @covers React\Stream\DuplexResourceStream::handleData
      */
     public function testDataEvent()
     {
@@ -111,7 +111,7 @@ class StreamTest extends TestCase
 
         $capturedData = null;
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->on('data', function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
@@ -124,8 +124,8 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @covers React\Stream\Stream::__construct
-     * @covers React\Stream\Stream::handleData
+     * @covers React\Stream\DuplexResourceStream::__construct
+     * @covers React\Stream\DuplexResourceStream::handleData
      */
     public function testDataEventDoesEmitOneChunkMatchingBufferSize()
     {
@@ -134,7 +134,7 @@ class StreamTest extends TestCase
 
         $capturedData = null;
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->on('data', function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
@@ -149,8 +149,8 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @covers React\Stream\Stream::__construct
-     * @covers React\Stream\Stream::handleData
+     * @covers React\Stream\DuplexResourceStream::__construct
+     * @covers React\Stream\DuplexResourceStream::handleData
      */
     public function testDataEventDoesEmitOneChunkUntilStreamEndsWhenBufferSizeIsInfinite()
     {
@@ -159,7 +159,7 @@ class StreamTest extends TestCase
 
         $capturedData = null;
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->bufferSize = null;
 
         $conn->on('data', function ($data) use (&$capturedData) {
@@ -176,28 +176,28 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @covers React\Stream\Stream::handleData
+     * @covers React\Stream\DuplexResourceStream::handleData
      */
     public function testEmptyStreamShouldNotEmitData()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->on('data', $this->expectCallableNever());
 
         $conn->handleData($stream);
     }
 
     /**
-     * @covers React\Stream\Stream::write
+     * @covers React\Stream\DuplexResourceStream::write
      */
     public function testWrite()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createWriteableLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->write("foo\n");
 
         rewind($stream);
@@ -205,16 +205,16 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @covers React\Stream\Stream::end
-     * @covers React\Stream\Stream::isReadable
-     * @covers React\Stream\Stream::isWritable
+     * @covers React\Stream\DuplexResourceStream::end
+     * @covers React\Stream\DuplexResourceStream::isReadable
+     * @covers React\Stream\DuplexResourceStream::isWritable
      */
     public function testEnd()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->end();
 
         $this->assertFalse(is_resource($stream));
@@ -228,7 +228,7 @@ class StreamTest extends TestCase
         $stream = fopen($file, 'r+');
         $loop = $this->createWriteableLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->write("foo\n");
         $conn->end();
 
@@ -246,7 +246,7 @@ class StreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $dest = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
 
         $this->assertSame($dest, $conn->pipe($dest));
@@ -257,7 +257,7 @@ class StreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
 
         $conn->on('drain', $this->expectCallableOnce());
         $conn->on('error', $this->expectCallableOnce());
@@ -268,14 +268,14 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @covers React\Stream\Stream::handleData
+     * @covers React\Stream\DuplexResourceStream::handleData
      */
     public function testClosingStreamInDataEventShouldNotTriggerError()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->on('data', function ($data) use ($conn) {
             $conn->close();
         });
@@ -287,7 +287,7 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @covers React\Stream\Stream::handleData
+     * @covers React\Stream\DuplexResourceStream::handleData
      */
     public function testDataFiltered()
     {
@@ -302,7 +302,7 @@ class StreamTest extends TestCase
 
         $capturedData = null;
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->on('data', function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
@@ -315,7 +315,7 @@ class StreamTest extends TestCase
     }
 
     /**
-     * @covers React\Stream\Stream::handleData
+     * @covers React\Stream\DuplexResourceStream::handleData
      */
     public function testDataErrorShouldEmitErrorAndClose()
     {
@@ -331,7 +331,7 @@ class StreamTest extends TestCase
 
         $loop = $this->createLoopMock();
 
-        $conn = new Stream($stream, $loop);
+        $conn = new DuplexResourceStream($stream, $loop);
         $conn->on('data', $this->expectCallableNever());
         $conn->on('error', $this->expectCallableOnce());
         $conn->on('close', $this->expectCallableOnce());


### PR DESCRIPTION
The old `Stream` has been renamed to `DuplexResourceStream` to complement the `ReadableResourceStream` and `WritableResourceStream` introduced via #83 and #84.

Note that the `DuplexResourceStream` now rejects read-only or write-only streams, so this may affect BC. If you want a read-only or write-only resource, use `ReadableResourceStream` or `WritableResourceStream` instead of `DuplexResourceStream`.

Also marking this as a bug fix because the old behavior with regards to stream resource that were not opened in duplex mode could actually result in runtime errors.

The `Stream` class is one of the main classes in this package, so I've added a deprecated dummy `Stream` class that simply extends the new `DuplexResourceStream` for BC reasons only. This means that existing packages can keep using the `Stream` class for "normal" resources such as TCP/IP connections with this version. This class exists to ease upgrading only and will be removed in the next version.

If you want to review, consider looking at the individual commits, this should make this slightly more obvious.

Resolves / closes #37
Builds on top of #83 and #84.