### PR TITLE
Consistent semantics for DuplexStreamInterface::end() to ensure it SHOULD also end readable side

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,16 @@ $stream->write('nope'); // NO-OP
 $stream->end(); // NO-OP
 ```
 
+If this stream is a `DuplexStreamInterface`, calling this method SHOULD
+also end its readable side, unless the stream supports half-open mode.
+In other words, after calling this method, these streams SHOULD switch
+into non-writable AND non-readable mode, see also `isReadable()`.
+This implies that in this case, the stream SHOULD NOT emit any `data`
+or `end` events anymore.
+Streams MAY choose to use the `pause()` method logic for this, but
+special care may have to be taken to ensure a following call to the
+`resume()` method SHOULD NOT continue emitting readable events.
+
 Note that this method should not be confused with the `close()` method.
 
 #### close()

--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -46,6 +46,10 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
 
     public function resume()
     {
+        if (!$this->writable->isWritable()) {
+            return;
+        }
+
         if ($this->pipeSource) {
             $this->pipeSource->resume();
         }
@@ -70,6 +74,7 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
 
     public function end($data = null)
     {
+        $this->readable->pause();
         $this->writable->end($data);
     }
 

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -146,6 +146,7 @@ class DuplexResourceStream extends EventEmitter implements DuplexStreamInterface
 
         $this->readable = false;
         $this->writable = false;
+        $this->pause();
 
         $this->buffer->end($data);
     }

--- a/src/WritableStreamInterface.php
+++ b/src/WritableStreamInterface.php
@@ -262,6 +262,16 @@ interface WritableStreamInterface extends EventEmitterInterface
      * $stream->end(); // NO-OP
      * ```
      *
+     * If this stream is a `DuplexStreamInterface`, calling this method SHOULD
+     * also end its readable side, unless the stream supports half-open mode.
+     * In other words, after calling this method, these streams SHOULD switch
+     * into non-writable AND non-readable mode, see also `isReadable()`.
+     * This implies that in this case, the stream SHOULD NOT emit any `data`
+     * or `end` events anymore.
+     * Streams MAY choose to use the `pause()` method logic for this, but
+     * special care may have to be taken to ensure a following call to the
+     * `resume()` method SHOULD NOT continue emitting readable events.
+     *
      * Note that this method should not be confused with the `close()` method.
      *
      * @param mixed|string|null $data

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -43,10 +43,32 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('resume');
         $writable = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $writable
+            ->expects($this->any())
+            ->method('isWritable')
+            ->willReturn(true);
 
         $composite = new CompositeStream($readable, $writable);
         $composite->isReadable();
         $composite->pause();
+        $composite->resume();
+    }
+
+    /** @test */
+    public function itShouldNotForwardResumeIfStreamIsNotWritable()
+    {
+        $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
+        $readable
+            ->expects($this->never())
+            ->method('resume');
+
+        $writable = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        $writable
+            ->expects($this->once())
+            ->method('isWritable')
+            ->willReturn(false);
+
+        $composite = new CompositeStream($readable, $writable);
         $composite->resume();
     }
 

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -237,6 +237,19 @@ class DuplexResourceStreamTest extends TestCase
         $this->assertFalse($conn->isWritable());
     }
 
+    /**
+     * @covers React\Stream\DuplexResourceStream::end
+     */
+    public function testEndRemovesReadStreamFromLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('removeReadStream');
+
+        $conn = new DuplexResourceStream($stream, $loop);
+        $conn->end('bye');
+    }
+
     public function testEndedStreamsShouldNotWrite()
     {
         $file = tempnam(sys_get_temp_dir(), 'reactphptest_');


### PR DESCRIPTION
The semantics for this are currently not explicit and the `DuplexResourceStream` (previously `Stream`) class has a very unclear `end()` logic implemented. It currently turns the stream into non-readable mode but keeps emitting readable events despite.

This PR ensures we use consistent semantics to ensure duplex streams SHOULD also end the readable side (unless this is a stream that supports half-open mode, see #27).

This should in fact not break any of the existing assumptions and as such should not be considered a BC break. Given that this current behavior was mostly underdocumented or undocumented, I'll mark this as a BC break just to be safe in case any implementation relies on undocumented features which might now be prohibited.

Builds on top of #72.