### PR TITLE
Simplify ThroughStream by using data callback instead of inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,23 @@ $through->on('data', $this->expectCallableOnceWith("[2, true]\n"));
 $through->write(array(2, true));
 ```
 
+The callback function is allowed to throw an `Exception`. In this case,
+the stream will emit an `error` event and then [`close()`](#close-1) the stream.
+
+```php
+$through = new ThroughStream(function ($data) {
+    if (!is_string($data)) {
+        throw new \UnexpectedValueException('Only strings allowed');
+    }
+    return $data;
+});
+$through->on('error', $this->expectCallableOnce()));
+$through->on('close', $this->expectCallableOnce()));
+$through->on('data', $this->expectCallableNever()));
+
+$through->write(2);
+```
+
 ## Usage
 ```php
     $loop = React\EventLoop\Factory::create();

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ descriptor based implementation with an in-memory write buffer.
   * [ReadableResourceStream](#readableresourcestream)
   * [WritableResourceStream](#writableresourcestream)
   * [DuplexResourceStream](#duplexresourcestream)
+  * [ThroughStream](#throughstream)
 * [Usage](#usage)
 * [Install](#install)
 * [Tests](#tests)
@@ -923,6 +924,53 @@ $buffer->softLimit = 8192;
 ```
 
 See also [`write()`](#write) for more details.
+
+### ThroughStream
+
+The `ThroughStream` implements the
+[`DuplexStreamInterface`](#duplexstreaminterface) and will simply pass any data
+you write to it through to its readable end.
+
+```php
+$through = new ThroughStream();
+$through->on('data', $this->expectCallableOnceWith('hello'));
+
+$through->write('hello');
+```
+
+Similarly, the [`end()` method](#end) will end the stream and emit an
+[`end` event](#end-event) and then [`close()`](#close-1) the stream.
+The [`close()` method](#close-1) will close the stream and emit a
+[`close` event](#close-event).
+Accordingly, this is can also be used in a [`pipe()`](#pipe) context like this:
+
+```php
+$through = new ThroughStream();
+$source->pipe($through)->pipe($dest);
+```
+
+Optionally, its constructor accepts any callable function which will then be
+used to *filter* any data written to it. This function receives a single data
+argument as passed to the writable side and must return the data as it will be
+passed to its readable end:
+
+```php
+$through = new ThroughStream('strtoupper');
+$source->pipe($through)->pipe($dest);
+```
+
+Note that this class makes no assumptions about any data types. This can be
+used to convert data, for example for transforming any structured data into
+a newline-delimited JSON (NDJSON) stream like this:
+
+```php
+$through = new ThroughStream(function ($data) {
+    return json_encode($data) . PHP_EOL;
+});
+$through->on('data', $this->expectCallableOnceWith("[2, true]\n"));
+
+$through->write(array(2, true));
+```
 
 ## Usage
 ```php

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -5,6 +5,57 @@ namespace React\Stream;
 use Evenement\EventEmitter;
 use InvalidArgumentException;
 
+/**
+ * The `ThroughStream` implements the
+ * [`DuplexStreamInterface`](#duplexstreaminterface) and will simply pass any data
+ * you write to it through to its readable end.
+ *
+ * ```php
+ * $through = new ThroughStream();
+ * $through->on('data', $this->expectCallableOnceWith('hello'));
+ *
+ * $through->write('hello');
+ * ```
+ *
+ * Similarly, the [`end()` method](#end) will end the stream and emit an
+ * [`end` event](#end-event) and then [`close()`](#close-1) the stream.
+ * The [`close()` method](#close-1) will close the stream and emit a
+ * [`close` event](#close-event).
+ * Accordingly, this is can also be used in a [`pipe()`](#pipe) context like this:
+ *
+ * ```php
+ * $through = new ThroughStream();
+ * $source->pipe($through)->pipe($dest);
+ * ```
+ *
+ * Optionally, its constructor accepts any callable function which will then be
+ * used to *filter* any data written to it. This function receives a single data
+ * argument as passed to the writable side and must return the data as it will be
+ * passed to its readable end:
+ *
+ * ```php
+ * $through = new ThroughStream('strtoupper');
+ * $source->pipe($through)->pipe($dest);
+ * ```
+ *
+ * Note that this class makes no assumptions about any data types. This can be
+ * used to convert data, for example for transforming any structured data into
+ * a newline-delimited JSON (NDJSON) stream like this:
+ *
+ * ```php
+ * $through = new ThroughStream(function ($data) {
+ *     return json_encode($data) . PHP_EOL;
+ * });
+ * $through->on('data', $this->expectCallableOnceWith("[2, true]\n"));
+ *
+ * $through->write(array(2, true));
+ * ```
+ *
+ * @see WritableStreamInterface::write()
+ * @see WritableStreamInterface::end()
+ * @see DuplexStreamInterface::close()
+ * @see WritableStreamInterface::pipe()
+ */
 class ThroughStream extends EventEmitter implements DuplexStreamInterface
 {
     private $readable = true;

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -53,6 +53,40 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
+    public function itShouldEmitErrorAndCloseIfCallbackThrowsException()
+    {
+        $through = new ThroughStream(function () {
+            throw new \RuntimeException();
+        });
+        $through->on('error', $this->expectCallableOnce());
+        $through->on('close', $this->expectCallableOnce());
+        $through->on('data', $this->expectCallableNever());
+        $through->on('end', $this->expectCallableNever());
+
+        $through->write('foo');
+
+        $this->assertFalse($through->isReadable());
+        $this->assertFalse($through->isWritable());
+    }
+
+    /** @test */
+    public function itShouldEmitErrorAndCloseIfCallbackThrowsExceptionOnEnd()
+    {
+        $through = new ThroughStream(function () {
+            throw new \RuntimeException();
+        });
+        $through->on('error', $this->expectCallableOnce());
+        $through->on('close', $this->expectCallableOnce());
+        $through->on('data', $this->expectCallableNever());
+        $through->on('end', $this->expectCallableNever());
+
+        $through->end('foo');
+
+        $this->assertFalse($through->isReadable());
+        $this->assertFalse($through->isWritable());
+    }
+
+    /** @test */
     public function itShouldReturnFalseForAnyDataWrittenToItWhenPaused()
     {
         $through = new ThroughStream();

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -10,6 +10,15 @@ use React\Stream\ThroughStream;
  */
 class ThroughStreamTest extends TestCase
 {
+    /**
+     * @test
+     * @expectedException InvalidArgumentException
+     */
+    public function itShouldRejectInvalidCallback()
+    {
+        new ThroughStream(123);
+    }
+
     /** @test */
     public function itShouldReturnTrueForAnyDataWrittenToIt()
     {
@@ -24,6 +33,22 @@ class ThroughStreamTest extends TestCase
     {
         $through = new ThroughStream();
         $through->on('data', $this->expectCallableOnceWith('foo'));
+        $through->write('foo');
+    }
+
+    /** @test */
+    public function itShouldEmitAnyDataWrittenToItPassedThruFunction()
+    {
+        $through = new ThroughStream('strtoupper');
+        $through->on('data', $this->expectCallableOnceWith('FOO'));
+        $through->write('foo');
+    }
+
+    /** @test */
+    public function itShouldEmitAnyDataWrittenToItPassedThruCallback()
+    {
+        $through = new ThroughStream('strtoupper');
+        $through->on('data', $this->expectCallableOnceWith('FOO'));
         $through->write('foo');
     }
 


### PR DESCRIPTION
Previously, one had to `extend` the `ThroughStream` in order to implement custom filtering behavior. However, there is no public implementation of this available: http://packanalyst.com/class?q=React%5CStream%5CThroughStream

With this PR applied, one can now simply pass a callback function to its constructor like this:

```php
$through = new ThroughStream(function ($data) {
    return json_encode($data) . PHP_EOL;
});
$through->on('data', $this->expectCallableOnceWith("[2, true]\n"));

$through->write(array(2, true));
```

Builds on top of #88