### PR TITLE
Remove public $stream property from all resource streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,12 +753,6 @@ Once the constructor is called with a valid stream resource, this class will
 take care of the underlying stream resource.
 You SHOULD only use its public API and SHOULD NOT interfere with the underlying
 stream resource manually.
-Should you need to access the underlying stream resource, you can use the public
-`$stream` property like this:
-
-```php
-var_dump(stream_get_meta_data($stream->stream));
-```
 
 The `$bufferSize` property controls the maximum buffer size in bytes to read
 at once from the stream.
@@ -819,12 +813,6 @@ Once the constructor is called with a valid stream resource, this class will
 take care of the underlying stream resource.
 You SHOULD only use its public API and SHOULD NOT interfere with the underlying
 stream resource manually.
-Should you need to access the underlying stream resource, you can use the public
-`$stream` property like this:
-
-```php
-var_dump(stream_get_meta_data($stream->stream));
-```
 
 Any `write()` calls to this class will not be performaned instantly, but will
 be performaned asynchronously, once the EventLoop reports the stream resource is
@@ -885,12 +873,6 @@ Once the constructor is called with a valid stream resource, this class will
 take care of the underlying stream resource.
 You SHOULD only use its public API and SHOULD NOT interfere with the underlying
 stream resource manually.
-Should you need to access the underlying stream resource, you can use the public
-`$stream` property like this:
-
-```php
-var_dump(stream_get_meta_data($stream->stream));
-```
 
 The `$bufferSize` property controls the maximum buffer size in bytes to read
 at once from the stream.

--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -21,7 +21,8 @@ if (extension_loaded('xdebug')) {
 $info->write('piping from ' . $if . ' to ' . $of . ' (for max ' . $t . ' second(s)) ...'. PHP_EOL);
 
 // setup input and output streams and pipe inbetween
-$in = new React\Stream\ReadableResourceStream(fopen($if, 'r'), $loop);
+$fh = fopen($if, 'r');
+$in = new React\Stream\ReadableResourceStream($fh, $loop);
 $out = new React\Stream\WritableResourceStream(fopen($of, 'w'), $loop);
 $in->pipe($out);
 
@@ -32,11 +33,11 @@ $timeout = $loop->addTimer($t, function () use ($in, &$bytes) {
 });
 
 // print stream position once stream closes
-$in->on('close', function () use ($in, $start, $timeout, $info) {
+$in->on('close', function () use ($fh, $start, $timeout, $info) {
     $t = microtime(true) - $start;
     $timeout->cancel();
 
-    $bytes = ftell($in->stream);
+    $bytes = ftell($fh);
 
     $info->write('read ' . $bytes . ' byte(s) in ' . round($t, 3) . ' second(s) => ' . round($bytes / 1024 / 1024 / $t, 1) . ' MiB/s' . PHP_EOL);
     $info->write('peak memory usage of ' . round(memory_get_peak_usage(true) / 1024 / 1024, 1) . ' MiB' . PHP_EOL);

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -26,7 +26,7 @@ class DuplexResourceStream extends EventEmitter implements DuplexStreamInterface
      */
     public $bufferSize = 65536;
 
-    public $stream;
+    private $stream;
     protected $readable = true;
     protected $writable = true;
     protected $closing = false;

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -31,7 +31,7 @@ class ReadableResourceStream extends EventEmitter implements ReadableStreamInter
     /**
      * @var resource
      */
-    public $stream;
+    private $stream;
 
     private $closed = false;
     private $loop;

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -7,7 +7,7 @@ use React\EventLoop\LoopInterface;
 
 class WritableResourceStream extends EventEmitter implements WritableStreamInterface
 {
-    public $stream;
+    private $stream;
     public $softLimit = 65536;
 
     private $listening = false;
@@ -118,9 +118,7 @@ class WritableResourceStream extends EventEmitter implements WritableStreamInter
         // Should this turn out to be a permanent error later, it will eventually
         // send *nothing* and we can detect this.
         if ($sent === 0 || $sent === false) {
-            if ($error === null) {
-                $error = new \RuntimeException('Send failed');
-            } else {
+            if ($error !== null) {
                 $error = new \ErrorException(
                     $error['message'],
                     0,
@@ -130,7 +128,7 @@ class WritableResourceStream extends EventEmitter implements WritableStreamInter
                 );
             }
 
-            $this->emit('error', array(new \RuntimeException('Unable to write to stream: ' . $error->getMessage(), 0, $error)));
+            $this->emit('error', array(new \RuntimeException('Unable to write to stream: ' . ($error !== null ? $error->getMessage() : 'Unknown error'), 0, $error)));
             $this->close();
 
             return;

--- a/tests/WritableStreamResourceTest.php
+++ b/tests/WritableStreamResourceTest.php
@@ -142,32 +142,6 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testWriteEmitsErrorWhenResourceIsNotWritable()
-    {
-        if (defined('HHVM_VERSION')) {
-            // via https://github.com/reactphp/stream/pull/52/files#r75493076
-            $this->markTestSkipped('HHVM allows writing to read-only memory streams');
-        }
-
-        $stream = fopen('php://temp', 'r+');
-        $loop = $this->createLoopMock();
-
-        $buffer = new WritableResourceStream($stream, $loop);
-
-        // nasty hack to replace with reaad-only stream resource
-        $buffer->stream = fopen('php://temp', 'r');
-
-        $buffer->on('error', $this->expectCallableOnce());
-        //$buffer->on('close', $this->expectCallableOnce());
-
-        $buffer->write('hello');
-        $buffer->handleWrite();
-    }
-
-    /**
-     * @covers React\Stream\WritableResourceStream::write
-     * @covers React\Stream\WritableResourceStream::handleWrite
-     */
     public function testWriteDetectsWhenOtherSideIsClosed()
     {
         list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);


### PR DESCRIPTION
Remove public $stream property from all resource streams. This property has attracted some low quality code and interacting with it could easily break the stream semantics.

Empirical evidence suggests this isn't really needed anyway, so I propose to remove it from the public API for now. Should we need this again in the future, it's a simple feature addition with no BC break, so I'd suggest removing this until we find a use case that actually relies on this. 