### PR TITLE
CompositeStream forwards pause to pipe source on first write attempt

### DIFF
--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -8,7 +8,6 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
 {
     protected $readable;
     protected $writable;
-    protected $pipeSource;
     protected $closed = false;
 
     public function __construct(ReadableStreamInterface $readable, WritableStreamInterface $writable)
@@ -21,13 +20,6 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
 
         $this->readable->on('close', array($this, 'close'));
         $this->writable->on('close', array($this, 'close'));
-
-        $this->on('pipe', array($this, 'handlePipeEvent'));
-    }
-
-    public function handlePipeEvent($source)
-    {
-        $this->pipeSource = $source;
     }
 
     public function isReadable()
@@ -37,10 +29,6 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
 
     public function pause()
     {
-        if ($this->pipeSource) {
-            $this->pipeSource->pause();
-        }
-
         $this->readable->pause();
     }
 
@@ -48,10 +36,6 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
     {
         if (!$this->writable->isWritable()) {
             return;
-        }
-
-        if ($this->pipeSource) {
-            $this->pipeSource->resume();
         }
 
         $this->readable->resume();
@@ -85,8 +69,6 @@ class CompositeStream extends EventEmitter implements DuplexStreamInterface
         }
 
         $this->closed = true;
-        $this->pipeSource = null;
-
         $this->readable->close();
         $this->writable->close();
 

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -147,66 +147,6 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldForwardPauseUpstreamWhenPipedTo()
-    {
-        $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
-        $readable->expects($this->any())->method('isReadable')->willReturn(true);
-        $writable = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
-        $writable->expects($this->any())->method('isWritable')->willReturn(true);
-
-        $composite = new CompositeStream($readable, $writable);
-
-        $input = $this->getMockBuilder('React\Stream\ThroughStream')->setMethods(array('pause', 'resume'))->getMock();
-        $input
-            ->expects($this->once())
-            ->method('pause');
-
-        $input->pipe($composite);
-        $composite->pause();
-    }
-
-    /** @test */
-    public function itShouldForwardResumeUpstreamWhenPipedTo()
-    {
-        $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
-        $readable->expects($this->any())->method('isReadable')->willReturn(true);
-        $writable = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
-        $writable->expects($this->any())->method('isWritable')->willReturn(true);
-
-        $composite = new CompositeStream($readable, $writable);
-
-        $input = $this->getMockBuilder('React\Stream\ThroughStream')->setMethods(array('pause', 'resume'))->getMock();
-        $input
-            ->expects($this->once())
-            ->method('resume');
-
-        $input->pipe($composite);
-        $composite->resume();
-    }
-
-    /** @test */
-    public function itShouldForwardPauseAndResumeUpstreamWhenPipedTo()
-    {
-        $readable = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
-        $writable = new ThroughStream();
-        $writable->pause();
-
-        $composite = new CompositeStream($readable, $writable);
-
-        $input = $this->getMockBuilder('React\Stream\ThroughStream')->setMethods(array('pause', 'resume'))->getMock();
-        $input
-            ->expects($this->once())
-            ->method('pause');
-        $input
-            ->expects($this->once())
-            ->method('resume');
-
-        $input->pipe($composite);
-        $input->emit('data', array('foo'));
-        $writable->emit('drain');
-    }
-
-    /** @test */
     public function itShouldForwardPipeCallsToReadableStream()
     {
         $readable = new ThroughStream();


### PR DESCRIPTION
Remove inconsistent and unneeded forwarding of calls to `pause()` and `resume()` to the source stream for `CompositeStream`. This is actually entirely unneeded as the source stream will be paused automatically once it tries writing data to a paused stream anyway. This is now consistent with how literally all other streams work.

I do not consider this to be a bug fix, a new feature nor a BC break. This undocumented forwarding is plain unneeded. Prior to #88 this would also have affected the `ThroughStream`, so it makes sense to address this as part of the same release.