### PR TITLE
Mark all classes as final

### DIFF
--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -4,7 +4,7 @@ namespace React\Stream;
 
 use Evenement\EventEmitter;
 
-class CompositeStream extends EventEmitter implements DuplexStreamInterface
+final class CompositeStream extends EventEmitter implements DuplexStreamInterface
 {
     protected $readable;
     protected $writable;

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -6,7 +6,7 @@ use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use InvalidArgumentException;
 
-class DuplexResourceStream extends EventEmitter implements DuplexStreamInterface
+final class DuplexResourceStream extends EventEmitter implements DuplexStreamInterface
 {
     private $stream;
     private $loop;

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -6,7 +6,7 @@ use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use InvalidArgumentException;
 
-class ReadableResourceStream extends EventEmitter implements ReadableStreamInterface
+final class ReadableResourceStream extends EventEmitter implements ReadableStreamInterface
 {
     /**
      * @var resource

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -73,7 +73,7 @@ use InvalidArgumentException;
  * @see DuplexStreamInterface::close()
  * @see WritableStreamInterface::pipe()
  */
-class ThroughStream extends EventEmitter implements DuplexStreamInterface
+final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 {
     private $readable = true;
     private $writable = true;

--- a/src/Util.php
+++ b/src/Util.php
@@ -2,7 +2,7 @@
 
 namespace React\Stream;
 
-class Util
+final class Util
 {
     /**
      * Pipes all the data from the given $source into the $dest

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -5,7 +5,7 @@ namespace React\Stream;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 
-class WritableResourceStream extends EventEmitter implements WritableStreamInterface
+final class WritableResourceStream extends EventEmitter implements WritableStreamInterface
 {
     private $stream;
     private $loop;


### PR DESCRIPTION
Classes should be used via composition rather than extension.
This reduces our API footprint and avoids future BC breaks by avoiding
exposing its internal assumptions.

Builds on top of #95