### PR TITLE
CompositeStream starts closed if either side is already closed

### DIFF
--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -15,6 +15,10 @@ final class CompositeStream extends EventEmitter implements DuplexStreamInterfac
         $this->readable = $readable;
         $this->writable = $writable;
 
+        if (!$readable->isReadable() || !$writable->isWritable()) {
+            return $this->close();
+        }
+
         Util::forwardEvents($this->readable, $this, array('data', 'end', 'error'));
         Util::forwardEvents($this->writable, $this, array('drain', 'error', 'pipe'));
 


### PR DESCRIPTION
If either side of the composite stream closes, it will also close the other side.

This PR ensures that if either side is already closed during instantiation, it will also close the other side. Depending on how you view this, this is either a new feature or a bug fix.