### PR TITLE
Add optional $writeChunkSize parameter for max number of bytes to write

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,21 @@ This value SHOULD NOT be changed unless you know what you're doing.
 $stream = new WritableResourceStream(STDOUT, $loop, 8192);
 ```
 
+This class takes an optional `int|null $writeChunkSize` parameter that controls
+this maximum buffer size in bytes to write at once to the stream.
+You can use a `null` value here in order to apply its default value.
+This value SHOULD NOT be changed unless you know what you're doing.
+This can be a positive number which means that up to X bytes will be written
+at once to the underlying stream resource. Note that the actual number
+of bytes written may be lower if the stream resource has less than X bytes
+currently available.
+This can be `-1` which means "write everything available" to the
+underlying stream resource.
+
+```php
+$stream = new WritableResourceStream(STDOUT, $loop, null, 8192);
+```
+
 See also [`write()`](#write) for more details.
 
 ### DuplexResourceStream

--- a/tests/FunctionalInternetTest.php
+++ b/tests/FunctionalInternetTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace React\Tests\Stream;
+
+use React\Stream\DuplexResourceStream;
+use React\EventLoop\Factory;
+use React\Stream\WritableResourceStream;
+
+/**
+ * @group internet
+ */
+class FunctionalInternetTest extends TestCase
+{
+    public function testUploadKilobytePlain()
+    {
+        $size = 1000;
+        $stream = stream_socket_client('tcp://httpbin.org:80');
+
+        $loop = Factory::create();
+        $stream = new DuplexResourceStream($stream, $loop);
+
+        $buffer = '';
+        $stream->on('data', function ($chunk) use (&$buffer) {
+            $buffer .= $chunk;
+        });
+
+        $stream->on('error', $this->expectCallableNever());
+
+        $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
+
+        $loop->run();
+
+        $this->assertNotEquals('', $buffer);
+    }
+
+    public function testUploadBiggerBlockPlain()
+    {
+        $size = 1000 * 30;
+        $stream = stream_socket_client('tcp://httpbin.org:80');
+
+        $loop = Factory::create();
+        $stream = new DuplexResourceStream($stream, $loop);
+
+        $buffer = '';
+        $stream->on('data', function ($chunk) use (&$buffer) {
+            $buffer .= $chunk;
+        });
+
+        $stream->on('error', $this->expectCallableNever());
+
+        $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
+
+        $loop->run();
+
+        $this->assertNotEquals('', $buffer);
+    }
+
+    public function testUploadKilobyteSecure()
+    {
+        $size = 1000;
+        $stream = stream_socket_client('tls://httpbin.org:443');
+
+        $loop = Factory::create();
+        $stream = new DuplexResourceStream($stream, $loop);
+
+        $buffer = '';
+        $stream->on('data', function ($chunk) use (&$buffer) {
+            $buffer .= $chunk;
+        });
+
+        $stream->on('error', $this->expectCallableNever());
+
+        $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
+
+        $loop->run();
+
+        $this->assertNotEquals('', $buffer);
+    }
+
+    public function testUploadBiggerBlockSecureRequiresSmallerChunkSize()
+    {
+        $size = 1000 * 30000;
+        $stream = stream_socket_client('tls://httpbin.org:443');
+
+        $loop = Factory::create();
+        $stream = new DuplexResourceStream(
+            $stream,
+            $loop,
+            null,
+            new WritableResourceStream($stream, $loop, null, 8192)
+        );
+
+        $buffer = '';
+        $stream->on('data', function ($chunk) use (&$buffer) {
+            $buffer .= $chunk;
+        });
+
+        $stream->on('error', $this->expectCallableNever());
+
+        $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
+
+        $loop->run();
+
+        $this->assertNotEquals('', $buffer);
+    }
+}


### PR DESCRIPTION
This complements the `$readChunkSize` that is available for the readable side of streams.

Among others, this can be used to work-around the TLS stream write issues for chunks larger than ~30KB mentioned in #64.