### PR TITLE
Ignore HHVM test failures for now until Travis tests work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
 matrix:
   allow_failures:
     - php: nightly
+    - php: hhvm
 
 install:
   - composer install --prefer-source


### PR DESCRIPTION
Ignore HHVM test failures for now until Travis tests work again.