### PR TITLE
Close the underlying stream when closing the stream

### DIFF
--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -94,6 +94,16 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 
         $this->emit('close', array($this));
         $this->removeAllListeners();
+
+        $this->handleClose();
+    }
+
+    /** @internal */
+    public function handleClose()
+    {
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
     }
 
     /** @internal */


### PR DESCRIPTION
Currently unlike `ReadableResourceStream` the `WritableResourceStream` doesn't automatically closes the underlying stream resource with `fclose`. This PR aims to add that, but as of creating this PR two tests fail, purposely not updated tests to discuss how to handle those here before fixing them.