### PR TITLE
Target evenement 3.0 a long side 2.0 and 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.3.8",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "evenement/evenement": "^2.0|^1.0"
+        "evenement/evenement": "^3.0 || ^2.0 || ^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8.10",


### PR DESCRIPTION
Événement `3.0` is nearly fully backwards compatible with `2.0` and `1.0` and `react/stream` is fully compatible with all three so why not support it. It packs some neat performance upgrades without any code changes on `react/stream`'s side :shipit: .