### PR TITLE
Lock Travis distro so new defaults will not break the build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: php
 
 php:
-  - 5.3
+# - 5.3 # requires old distro, see below
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
-  - nightly
+  - nightly # ignore errors, see below
+  - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
-dist: precise
+dist: trusty
 
-# also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:
-    - php: hhvm
-      dist: trusty
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,18 @@ php:
   - 7.0
   - 7.1
   - nightly
-  - hhvm
 
+# also test against HHVM, but require "trusty" and ignore errors
 matrix:
+  include:
+    - php: hhvm
+      dist: trusty
   allow_failures:
     - php: nightly
     - php: hhvm
 
 install:
-  - composer install --prefer-source
+  - composer install --no-interaction
 
 script:
   - vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ php:
   - 7.1
   - nightly
 
+# lock distro so new future defaults will not break the build
+dist: precise
+
 # also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:


### PR DESCRIPTION
Travis is in the process of upgrading the base distro (https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) and despite all PRs currently being "green", will soon start to mark the current master as broken.

While updating the default distro, they also removed support for some older versions of PHP (travis-ci/travis-ci#7163). These versions are still supported by this project, so we now have to explicitly define the base distro to test against.

Builds on top of #106
Originally from https://github.com/clue/php-connection-manager-extra/pull/24