### PR TITLE
Fix forward compatibility with upcoming EventLoop releases in example

### DIFF
--- a/examples/benchmark-throughput.php
+++ b/examples/benchmark-throughput.php
@@ -33,9 +33,9 @@ $timeout = $loop->addTimer($t, function () use ($in, &$bytes) {
 });
 
 // print stream position once stream closes
-$in->on('close', function () use ($fh, $start, $timeout, $info) {
+$in->on('close', function () use ($fh, $start, $loop, $timeout, $info) {
     $t = microtime(true) - $start;
-    $timeout->cancel();
+    $loop->cancelTimer($timeout);
 
     $bytes = ftell($fh);
 


### PR DESCRIPTION
This fixes a small oversight from #94: The example still used the deprecated cancel() method which will be removed in the upcoming EventLoop release.

Builds on top of #94