### PR TITLE
 Remove event listeners from CompositeStream once closed and remove remove undocumented left-over close event argument 

### DIFF
--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -6,9 +6,9 @@ use Evenement\EventEmitter;
 
 final class CompositeStream extends EventEmitter implements DuplexStreamInterface
 {
-    protected $readable;
-    protected $writable;
-    protected $closed = false;
+    private $readable;
+    private $writable;
+    private $closed = false;
 
     public function __construct(ReadableStreamInterface $readable, WritableStreamInterface $writable)
     {
@@ -77,5 +77,6 @@ final class CompositeStream extends EventEmitter implements DuplexStreamInterfac
         $this->writable->close();
 
         $this->emit('close');
+        $this->removeAllListeners();
     }
 }

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -92,15 +92,9 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         $this->writable = false;
         $this->data = '';
 
-        $this->emit('close', array($this));
+        $this->emit('close');
         $this->removeAllListeners();
 
-        $this->handleClose();
-    }
-
-    /** @internal */
-    public function handleClose()
-    {
         if (is_resource($this->stream)) {
             fclose($this->stream);
         }

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -189,6 +189,25 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
+    public function itShouldForwardCloseAndRemoveAllListeners()
+    {
+        $in = new ThroughStream();
+
+        $composite = new CompositeStream($in, $in);
+        $composite->on('close', $this->expectCallableOnce());
+
+        $this->assertTrue($composite->isReadable());
+        $this->assertTrue($composite->isWritable());
+        $this->assertCount(1, $composite->listeners('close'));
+
+        $composite->close();
+
+        $this->assertFalse($composite->isReadable());
+        $this->assertFalse($composite->isWritable());
+        $this->assertCount(0, $composite->listeners('close'));
+    }
+
+    /** @test */
     public function itShouldReceiveForwardedEvents()
     {
         $readable = new ThroughStream();


### PR DESCRIPTION
This simple PR ensures that pending event listeners are removed after closing the (rarely used) `CompositeStream` in order to simplify garbage collection.

Builds on top of #107 and #69