### PR TITLE
Igore excessive fopen() mode flags for WritableResourceStream

### DIFF
--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -25,7 +25,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 
         // ensure resource is opened for writing (fopen mode must contain either of "waxc+")
         $meta = stream_get_meta_data($stream);
-        if (isset($meta['mode']) && strtr($meta['mode'], 'waxc+', '.....') === $meta['mode']) {
+        if (isset($meta['mode']) && $meta['mode'] !== '' && strtr($meta['mode'], 'waxc+', '.....') === $meta['mode']) {
             throw new \InvalidArgumentException('Given stream resource is not opened in write mode');
         }
 

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -23,8 +23,9 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
+        // ensure resource is opened for writing (fopen mode must contain either of "waxc+")
         $meta = stream_get_meta_data($stream);
-        if (isset($meta['mode']) && str_replace(array('b', 't'), '', $meta['mode']) === 'r') {
+        if (isset($meta['mode']) && strtr($meta['mode'], 'waxc+', '.....') === $meta['mode']) {
             throw new \InvalidArgumentException('Given stream resource is not opened in write mode');
         }
 

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -22,6 +22,21 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      */
+    public function testConstructorWithExcessiveMode()
+    {
+        // excessive flags are ignored for temp streams, so we have to use a file stream
+        $name = tempnam(sys_get_temp_dir(), 'test');
+        $stream = @fopen($name, 'r+eANYTHING');
+        unlink($name);
+
+        $loop = $this->createLoopMock();
+        $buffer = new DuplexResourceStream($stream, $loop);
+        $buffer->close();
+    }
+
+    /**
+     * @covers React\Stream\DuplexResourceStream::__construct
+     */
     public function testConstructorThrowsExceptionOnInvalidStream()
     {
         $loop = $this->createLoopMock();
@@ -43,6 +58,21 @@ class DuplexResourceStreamTest extends TestCase
 
         $this->setExpectedException('InvalidArgumentException');
         new DuplexResourceStream(STDOUT, $loop);
+    }
+
+    /**
+     * @covers React\Stream\DuplexResourceStream::__construct
+     * @expectedException InvalidArgumentException
+     */
+    public function testConstructorThrowsExceptionOnWriteOnlyStreamWithExcessiveMode()
+    {
+        // excessive flags are ignored for temp streams, so we have to use a file stream
+        $name = tempnam(sys_get_temp_dir(), 'test');
+        $stream = fopen($name, 'weANYTHING');
+        unlink($name);
+
+        $loop = $this->createLoopMock();
+        new DuplexResourceStream($stream, $loop);
     }
 
     /**

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -21,6 +21,21 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
      */
+    public function testConstructorWithExcessiveMode()
+    {
+        // excessive flags are ignored for temp streams, so we have to use a file stream
+        $name = tempnam(sys_get_temp_dir(), 'test');
+        $stream = @fopen($name, 'r+eANYTHING');
+        unlink($name);
+
+        $loop = $this->createLoopMock();
+        $buffer = new ReadableResourceStream($stream, $loop);
+        $buffer->close();
+    }
+
+    /**
+     * @covers React\Stream\ReadableResourceStream::__construct
+     */
     public function testConstructorThrowsExceptionOnInvalidStream()
     {
         $loop = $this->createLoopMock();
@@ -42,6 +57,21 @@ class ReadableResourceStreamTest extends TestCase
 
         $this->setExpectedException('InvalidArgumentException');
         new ReadableResourceStream(STDOUT, $loop);
+    }
+
+    /**
+     * @covers React\Stream\ReadableResourceStream::__construct
+     * @expectedException InvalidArgumentException
+     */
+    public function testConstructorThrowsExceptionOnWriteOnlyStreamWithExcessiveMode()
+    {
+        // excessive flags are ignored for temp streams, so we have to use a file stream
+        $name = tempnam(sys_get_temp_dir(), 'test');
+        $stream = fopen($name, 'weANYTHING');
+        unlink($name);
+
+        $loop = $this->createLoopMock();
+        new ReadableResourceStream($stream, $loop);
     }
 
     /**

--- a/tests/WritableStreamResourceTest.php
+++ b/tests/WritableStreamResourceTest.php
@@ -21,6 +21,21 @@ class WritableResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\WritableResourceStream::__construct
+     */
+    public function testConstructorWithExcessiveMode()
+    {
+        // excessive flags are ignored for temp streams, so we have to use a file stream
+        $name = tempnam(sys_get_temp_dir(), 'test');
+        $stream = @fopen($name, 'w+eANYTHING');
+        unlink($name);
+
+        $loop = $this->createLoopMock();
+        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer->close();
+    }
+
+    /**
+     * @covers React\Stream\WritableResourceStream::__construct
      * @expectedException InvalidArgumentException
      */
     public function testConstructorThrowsIfNotAValidStreamResource()
@@ -40,6 +55,21 @@ class WritableResourceStreamTest extends TestCase
         $stream = fopen('php://temp', 'r');
         $loop = $this->createLoopMock();
 
+        new WritableResourceStream($stream, $loop);
+    }
+
+    /**
+     * @covers React\Stream\WritableResourceStream::__construct
+     * @expectedException InvalidArgumentException
+     */
+    public function testConstructorThrowsExceptionOnReadOnlyStreamWithExcessiveMode()
+    {
+        // excessive flags are ignored for temp streams, so we have to use a file stream
+        $name = tempnam(sys_get_temp_dir(), 'test');
+        $stream = fopen($name, 'reANYTHING');
+        unlink($name);
+
+        $loop = $this->createLoopMock();
         new WritableResourceStream($stream, $loop);
     }
 


### PR DESCRIPTION
This fixes a minor issue where valid stream resources opened with valid flags such as `re` where not properly rejected.

Builds on top of #83, #84, #85