### PR TITLE
Fix forward compatibility with upcoming EventLoop releases

### DIFF
--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -131,11 +131,13 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         $this->writable = false;
 
         $this->emit('close');
-        $this->loop->removeStream($this->stream);
+        $this->pause();
         $this->buffer->close();
         $this->removeAllListeners();
 
-        $this->handleClose();
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
     }
 
     public function end($data = null)
@@ -188,14 +190,6 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
             // no data read => we reached the end and close the stream
             $this->emit('end');
             $this->close();
-        }
-    }
-
-    /** @internal */
-    public function handleClose()
-    {
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
         }
     }
 

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -33,6 +33,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     private $readable = true;
     private $writable = true;
     private $closing = false;
+    private $listening = false;
 
     public function __construct($stream, LoopInterface $loop, $readChunkSize = null, WritableStreamInterface $buffer = null)
     {
@@ -100,13 +101,17 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
 
     public function pause()
     {
-        $this->loop->removeReadStream($this->stream);
+        if ($this->listening) {
+            $this->loop->removeReadStream($this->stream);
+            $this->listening = false;
+        }
     }
 
     public function resume()
     {
-        if ($this->readable) {
+        if (!$this->listening && $this->readable) {
             $this->loop->addReadStream($this->stream, array($this, 'handleData'));
+            $this->listening = true;
         }
     }
 

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -36,6 +36,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     private $bufferSize;
 
     private $closed = false;
+    private $listening = false;
 
     public function __construct($stream, LoopInterface $loop, $readChunkSize = null)
     {
@@ -81,13 +82,17 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
 
     public function pause()
     {
-        $this->loop->removeReadStream($this->stream);
+        if ($this->listening) {
+            $this->loop->removeReadStream($this->stream);
+            $this->listening = false;
+        }
     }
 
     public function resume()
     {
-        if (!$this->closed) {
+        if (!$this->listening && !$this->closed) {
             $this->loop->addReadStream($this->stream, array($this, 'handleData'));
+            $this->listening = true;
         }
     }
 

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -105,10 +105,12 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         $this->closed = true;
 
         $this->emit('close');
-        $this->loop->removeStream($this->stream);
+        $this->pause();
         $this->removeAllListeners();
 
-        $this->handleClose();
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
     }
 
     /** @internal */
@@ -141,14 +143,6 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
             // no data read => we reached the end and close the stream
             $this->emit('end');
             $this->close();
-        }
-    }
-
-    /** @internal */
-    public function handleClose()
-    {
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
         }
     }
 

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -250,6 +250,35 @@ class DuplexResourceStreamTest extends TestCase
     }
 
     /**
+     * @covers React\Stream\DuplexResourceStream::pause
+     */
+    public function testPauseRemovesReadStreamFromLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
+
+        $conn = new DuplexResourceStream($stream, $loop);
+        $conn->pause();
+        $conn->pause();
+    }
+
+    /**
+     * @covers React\Stream\DuplexResourceStream::pause
+     */
+    public function testResumeDoesAddStreamToLoopOnlyOnce()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+
+        $conn = new DuplexResourceStream($stream, $loop);
+        $conn->resume();
+        $conn->resume();
+    }
+
+    /**
      * @covers React\Stream\DuplexResourceStream::close
      */
     public function testCloseRemovesReadStreamFromLoop()
@@ -261,6 +290,35 @@ class DuplexResourceStreamTest extends TestCase
 
         $conn = new DuplexResourceStream($stream, $loop);
         $conn->close();
+    }
+
+    /**
+     * @covers React\Stream\DuplexResourceStream::close
+     */
+    public function testCloseAfterPauseRemovesReadStreamFromLoopOnlyOnce()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
+
+        $conn = new DuplexResourceStream($stream, $loop);
+        $conn->pause();
+        $conn->close();
+    }
+
+    /**
+     * @covers React\Stream\DuplexResourceStream::close
+     */
+    public function testResumeAfterCloseDoesAddReadStreamToLoopOnlyOnce()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+
+        $conn = new DuplexResourceStream($stream, $loop);
+        $conn->close();
+        $conn->resume();
     }
 
     public function testEndedStreamsShouldNotWrite()

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -242,10 +242,25 @@ class DuplexResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
-        $loop->expects($this->once())->method('removeReadStream');
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
 
         $conn = new DuplexResourceStream($stream, $loop);
         $conn->end('bye');
+    }
+
+    /**
+     * @covers React\Stream\DuplexResourceStream::close
+     */
+    public function testCloseRemovesReadStreamFromLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
+
+        $conn = new DuplexResourceStream($stream, $loop);
+        $conn->close();
     }
 
     public function testEndedStreamsShouldNotWrite()

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -205,6 +205,20 @@ class ReadableResourceStreamTest extends TestCase
     }
 
     /**
+     * @covers React\Stream\ReadableResourceStream::close
+     */
+    public function testCloseRemovesReadStreamFromLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
+
+        $conn = new ReadableResourceStream($stream, $loop);
+        $conn->close();
+    }
+
+    /**
      * @covers React\Stream\ReadableResourceStream::handleData
      */
     public function testDataFiltered()

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -205,6 +205,35 @@ class ReadableResourceStreamTest extends TestCase
     }
 
     /**
+     * @covers React\Stream\ReadableResourceStream::pause
+     */
+    public function testPauseRemovesReadStreamFromLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
+
+        $conn = new ReadableResourceStream($stream, $loop);
+        $conn->pause();
+        $conn->pause();
+    }
+
+    /**
+     * @covers React\Stream\ReadableResourceStream::pause
+     */
+    public function testResumeDoesAddStreamToLoopOnlyOnce()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+
+        $conn = new ReadableResourceStream($stream, $loop);
+        $conn->resume();
+        $conn->resume();
+    }
+
+    /**
      * @covers React\Stream\ReadableResourceStream::close
      */
     public function testCloseRemovesReadStreamFromLoop()
@@ -216,6 +245,35 @@ class ReadableResourceStreamTest extends TestCase
 
         $conn = new ReadableResourceStream($stream, $loop);
         $conn->close();
+    }
+
+    /**
+     * @covers React\Stream\ReadableResourceStream::close
+     */
+    public function testCloseAfterPauseRemovesReadStreamFromLoopOnce()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+        $loop->expects($this->once())->method('removeReadStream')->with($stream);
+
+        $conn = new ReadableResourceStream($stream, $loop);
+        $conn->pause();
+        $conn->close();
+    }
+
+    /**
+     * @covers React\Stream\ReadableResourceStream::close
+     */
+    public function testResumeAfterCloseDoesAddReadStreamToLoopOnlyOnce()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $loop = $this->createLoopMock();
+        $loop->expects($this->once())->method('addReadStream')->with($stream);
+
+        $conn = new ReadableResourceStream($stream, $loop);
+        $conn->close();
+        $conn->resume();
     }
 
     /**


### PR DESCRIPTION
This ensures that the stream resources will only be added to and removed from the EventLoop if applicable. This ensures compatibility with the stricter definition of upcoming EventLoop releases and to prevent related issues. This is not an issue at the time of filing this PR. 

Refs https://github.com/reactphp/event-loop/pull/110 and https://github.com/reactphp/event-loop/pull/118
Builds on top of #94