### PR TITLE
Forward compatibility with PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 || ^4.8.35",
+        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35",
         "clue/stream-filter": "~1.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0 || ^4.8.10",
+        "phpunit/phpunit": "^5.7 || ^4.8.35",
         "clue/stream-filter": "~1.2"
     },
     "suggest": {

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -36,17 +36,18 @@ class DuplexResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
+     * @expectedException InvalidArgumentException
      */
     public function testConstructorThrowsExceptionOnInvalidStream()
     {
         $loop = $this->createLoopMock();
 
-        $this->setExpectedException('InvalidArgumentException');
         new DuplexResourceStream('breakme', $loop);
     }
 
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
+     * @expectedException InvalidArgumentException
      */
     public function testConstructorThrowsExceptionOnWriteOnlyStream()
     {
@@ -56,7 +57,6 @@ class DuplexResourceStreamTest extends TestCase
 
         $loop = $this->createLoopMock();
 
-        $this->setExpectedException('InvalidArgumentException');
         new DuplexResourceStream(STDOUT, $loop);
     }
 
@@ -77,6 +77,7 @@ class DuplexResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
+     * @expectedException RunTimeException
      */
     public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
     {
@@ -87,7 +88,6 @@ class DuplexResourceStreamTest extends TestCase
         $stream = fopen('blocking://test', 'r+');
         $loop = $this->createLoopMock();
 
-        $this->setExpectedException('RuntimeException');
         new DuplexResourceStream($stream, $loop);
     }
 

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -35,17 +35,18 @@ class ReadableResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
+     * @expectedException InvalidArgumentException
      */
     public function testConstructorThrowsExceptionOnInvalidStream()
     {
         $loop = $this->createLoopMock();
 
-        $this->setExpectedException('InvalidArgumentException');
         new ReadableResourceStream(false, $loop);
     }
 
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
+     * @expectedException InvalidArgumentException
      */
     public function testConstructorThrowsExceptionOnWriteOnlyStream()
     {
@@ -55,7 +56,6 @@ class ReadableResourceStreamTest extends TestCase
 
         $loop = $this->createLoopMock();
 
-        $this->setExpectedException('InvalidArgumentException');
         new ReadableResourceStream(STDOUT, $loop);
     }
 
@@ -76,6 +76,7 @@ class ReadableResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
+     * @expectedException RuntimeException
      */
     public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
     {
@@ -86,7 +87,6 @@ class ReadableResourceStreamTest extends TestCase
         $stream = fopen('blocking://test', 'r+');
         $loop = $this->createLoopMock();
 
-        $this->setExpectedException('RuntimeException');
         new ReadableResourceStream($stream, $loop);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace React\Tests\Stream;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
 {
     protected function expectCallableExactly($amount)
     {

--- a/tests/WritableStreamResourceTest.php
+++ b/tests/WritableStreamResourceTest.php
@@ -75,6 +75,7 @@ class WritableResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\WritableResourceStream::__construct
+     * @expectedException RuntimeException
      */
     public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
     {
@@ -85,7 +86,6 @@ class WritableResourceStreamTest extends TestCase
         $stream = fopen('blocking://test', 'r+');
         $loop = $this->createLoopMock();
 
-        $this->setExpectedException('RuntimeException');
         new WritableResourceStream($stream, $loop);
     }
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.