### PR TITLE
Work around reading from unbuffered pipe stream in legacy PHP < 5.4.28 and PHP < 5.5.12

### DIFF
--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -60,7 +60,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         // This does not affect the default event loop implementation (level
         // triggered), so we can ignore platforms not supporting this (HHVM).
         // Pipe streams (such as STDIN) do not seem to require this and legacy
-        // PHP < 5.4 causes SEGFAULTs on unbuffered pipe streams, so skip this.
+        // PHP versions cause SEGFAULTs on unbuffered pipe streams, so skip this.
         if (function_exists('stream_set_read_buffer') && !$this->isLegacyPipe($stream)) {
             stream_set_read_buffer($stream, 0);
         }
@@ -201,14 +201,18 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     /**
      * Returns whether this is a pipe resource in a legacy environment
      *
+     * This works around a legacy PHP bug (#61019) that was fixed in PHP 5.4.28+
+     * and PHP 5.5.12+ and newer.
+     *
      * @param resource $resource
      * @return bool
+     * @link https://github.com/reactphp/child-process/issues/40
      *
      * @codeCoverageIgnore
      */
     private function isLegacyPipe($resource)
     {
-        if (PHP_VERSION_ID < 50400) {
+        if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512)) {
             $meta = stream_get_meta_data($resource);
 
             if (isset($meta['stream_type']) && $meta['stream_type'] === 'STDIO') {

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -63,7 +63,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         // This does not affect the default event loop implementation (level
         // triggered), so we can ignore platforms not supporting this (HHVM).
         // Pipe streams (such as STDIN) do not seem to require this and legacy
-        // PHP < 5.4 causes SEGFAULTs on unbuffered pipe streams, so skip this.
+        // PHP versions cause SEGFAULTs on unbuffered pipe streams, so skip this.
         if (function_exists('stream_set_read_buffer') && !$this->isLegacyPipe($stream)) {
             stream_set_read_buffer($stream, 0);
         }
@@ -154,14 +154,18 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     /**
      * Returns whether this is a pipe resource in a legacy environment
      *
+     * This works around a legacy PHP bug (#61019) that was fixed in PHP 5.4.28+
+     * and PHP 5.5.12+ and newer.
+     *
      * @param resource $resource
      * @return bool
+     * @link https://github.com/reactphp/child-process/issues/40
      *
      * @codeCoverageIgnore
      */
     private function isLegacyPipe($resource)
     {
-        if (PHP_VERSION_ID < 50400) {
+        if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512)) {
             $meta = stream_get_meta_data($resource);
 
             if (isset($meta['stream_type']) && $meta['stream_type'] === 'STDIO') {


### PR DESCRIPTION
We've been able to track this back to legacy PHP bug https://bugs.php.net/bug.php?id=61019 which was fixed via https://github.com/php/php-src/commit/1ec83d44a1601c3560f430e08af9698bf8fb075c.

This patch avoids switching to unbuffered mode for pipe streams on PHP < 5.4.28 and PHP < 5.5.12 and thus avoids this issue on all versions. Technically, unbuffered reads aren't really needed here for any PHP version, but not using unbuffered reads shows a 10%-20% performance penalty.

Builds on top of #80
Refs https://github.com/reactphp/child-process/issues/40