### PR TITLE
Fix test suite when using legacy LibEventLoop and avoid risky tests

### DIFF
--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -30,7 +30,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
                     return function_exists('event_base_new');
                 },
                 function () {
-                    return class_exists('React\EventLoop\ExtLibeventLoop') ? new ExtLibeventLoop() : LibEventLoop();
+                    return class_exists('React\EventLoop\ExtLibeventLoop') ? new ExtLibeventLoop() : new LibEventLoop();
                 }
             ),
             array(

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -10,17 +10,19 @@ class DuplexResourceStreamTest extends TestCase
 {
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstructor()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $conn = new DuplexResourceStream($stream, $loop);
+        new DuplexResourceStream($stream, $loop);
     }
 
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstructorWithExcessiveMode()
     {
@@ -93,6 +95,7 @@ class DuplexResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstructorAcceptsBuffer()
     {
@@ -405,6 +408,7 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
+        $conn->on('error', $this->expectCallableNever());
         $conn->on('data', function ($data) use ($conn) {
             $conn->close();
         });

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -9,6 +9,7 @@ class ReadableResourceStreamTest extends TestCase
 {
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstructor()
     {
@@ -20,6 +21,7 @@ class ReadableResourceStreamTest extends TestCase
 
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstructorWithExcessiveMode()
     {
@@ -224,6 +226,7 @@ class ReadableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
+        $conn->on('error', $this->expectCallableNever());
         $conn->on('data', function ($data) use ($conn) {
             $conn->close();
         });

--- a/tests/WritableStreamResourceTest.php
+++ b/tests/WritableStreamResourceTest.php
@@ -9,18 +9,19 @@ class WritableResourceStreamTest extends TestCase
 {
     /**
      * @covers React\Stream\WritableResourceStream::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstructor()
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
 
-        $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', $this->expectCallableNever());
+        new WritableResourceStream($stream, $loop);
     }
 
     /**
      * @covers React\Stream\WritableResourceStream::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstructorWithExcessiveMode()
     {


### PR DESCRIPTION
This simple PR fixes a minor typo recently introduced via #128. Also, while I'm at it, this also includes some trivial adjustments to avoid risky tests (as of #122).

Builds on top of #128 and #122