### PR TITLE
Add test group to skip integration tests relying on internet connection and apply timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,14 @@ To run the test suite, go to the project root and run:
 $ php vendor/bin/phpunit
 ```
 
+The test suite also contains a number of functional integration tests that rely
+on a stable internet connection.
+If you do not want to run these, they can simply be skipped like this:
+
+```bash
+$ php vendor/bin/phpunit --exclude-group internet
+```
+
 ## License
 
 MIT, see [LICENSE file](LICENSE).

--- a/tests/FunctionalInternetTest.php
+++ b/tests/FunctionalInternetTest.php
@@ -2,8 +2,8 @@
 
 namespace React\Tests\Stream;
 
-use React\Stream\DuplexResourceStream;
 use React\EventLoop\Factory;
+use React\Stream\DuplexResourceStream;
 use React\Stream\WritableResourceStream;
 
 /**
@@ -35,7 +35,7 @@ class FunctionalInternetTest extends TestCase
 
     public function testUploadBiggerBlockPlain()
     {
-        $size = 1000 * 30;
+        $size = 50 * 1000;
         $stream = stream_socket_client('tcp://httpbin.org:80');
 
         $loop = Factory::create();
@@ -79,7 +79,7 @@ class FunctionalInternetTest extends TestCase
 
     public function testUploadBiggerBlockSecureRequiresSmallerChunkSize()
     {
-        $size = 1000 * 30000;
+        $size = 50 * 1000;
         $stream = stream_socket_client('tls://httpbin.org:443');
 
         $loop = Factory::create();


### PR DESCRIPTION
The test suite contains some tests that rely on a working internet connection and upload more than 30 MB(!) and does not apply any timeouts for this. This simple PR reduces this size to 50 KB (which exhibits the same behavior as documented in #105) and applies a timeout of 10s for each test. Additionally, we now document this in our README and give instructions on how these tests can be skipped.

Builds on top of #105
Refs https://github.com/reactphp/socket/pull/146