### PR TITLE
Changes event handling to use constants instead of raw strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+zero.bin

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "autoload": {
         "psr-4": {
             "React\\Stream\\": "src"
-        }
+        },
+        "files": ["./src/events.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -13,6 +13,7 @@
 
 use React\EventLoop\Factory;
 use React\Stream\DuplexResourceStream;
+use React\Stream\Event;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -28,10 +29,10 @@ if (!$resource) {
 $loop = Factory::create();
 $stream = new DuplexResourceStream($resource, $loop);
 
-$stream->on('data', function ($chunk) {
+$stream->on(Event\DATA, function ($chunk) {
     echo $chunk;
 });
-$stream->on('close', function () {
+$stream->on(Event\CLOSE, function () {
     echo '[CLOSED]' . PHP_EOL;
 });
 

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -13,6 +13,7 @@
 
 use React\EventLoop\Factory;
 use React\Stream\DuplexResourceStream;
+use React\Stream\Event;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -28,10 +29,10 @@ if (!$resource) {
 $loop = Factory::create();
 $stream = new DuplexResourceStream($resource, $loop);
 
-$stream->on('data', function ($chunk) {
+$stream->on(Event\DATA, function ($chunk) {
     echo $chunk;
 });
-$stream->on('close', function () {
+$stream->on(Event\CLOSE, function () {
     echo '[CLOSED]' . PHP_EOL;
 });
 

--- a/examples/91-benchmark-throughput.php
+++ b/examples/91-benchmark-throughput.php
@@ -2,7 +2,7 @@
 
 // Benchmark to measure throughput performance piping an input stream to an output stream.
 // This allows you to get an idea of how fast stream processing with PHP can be
-// and also to play around with differnt types of input and output streams.
+// and also to play around with different types of input and output streams.
 //
 // This example accepts a number of parameters to control the timeout (-t 1),
 // the input file (-i /dev/zero) and the output file (-o /dev/null).
@@ -12,6 +12,8 @@
 // $ php examples/91-benchmark-throughput.php -t 60 -i zero.bin
 
 require __DIR__ . '/../vendor/autoload.php';
+
+use React\Stream\Event;
 
 if (DIRECTORY_SEPARATOR === '\\') {
     fwrite(STDERR, 'Non-blocking console I/O not supported on Microsoft Windows' . PHP_EOL);
@@ -49,7 +51,7 @@ $timeout = $loop->addTimer($t, function () use ($in, &$bytes) {
 });
 
 // print stream position once stream closes
-$in->on('close', function () use ($fh, $start, $loop, $timeout, $info) {
+$in->on(Event\CLOSE, function () use ($fh, $start, $loop, $timeout, $info) {
     $t = microtime(true) - $start;
     $loop->cancelTimer($timeout);
 

--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -3,6 +3,7 @@
 namespace React\Stream;
 
 use Evenement\EventEmitter;
+use React\Stream\Event;
 
 final class CompositeStream extends EventEmitter implements DuplexStreamInterface
 {
@@ -19,11 +20,11 @@ final class CompositeStream extends EventEmitter implements DuplexStreamInterfac
             return $this->close();
         }
 
-        Util::forwardEvents($this->readable, $this, array('data', 'end', 'error'));
-        Util::forwardEvents($this->writable, $this, array('drain', 'error', 'pipe'));
+        Util::forwardEvents($this->readable, $this, array(Event\DATA, Event\END, Event\ERROR));
+        Util::forwardEvents($this->writable, $this, array(Event\DRAIN, Event\ERROR, Event\PIPE));
 
-        $this->readable->on('close', array($this, 'close'));
-        $this->writable->on('close', array($this, 'close'));
+        $this->readable->on(Event\CLOSE, array($this, 'close'));
+        $this->writable->on(Event\CLOSE, array($this, 'close'));
     }
 
     public function isReadable()
@@ -76,7 +77,7 @@ final class CompositeStream extends EventEmitter implements DuplexStreamInterfac
         $this->readable->close();
         $this->writable->close();
 
-        $this->emit('close');
+        $this->emit(Event\CLOSE);
         $this->removeAllListeners();
     }
 }

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -5,6 +5,7 @@ namespace React\Stream;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use InvalidArgumentException;
+use React\Stream\Event;
 
 final class ReadableResourceStream extends EventEmitter implements ReadableStreamInterface
 {
@@ -109,7 +110,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
 
         $this->closed = true;
 
-        $this->emit('close');
+        $this->emit(Event\CLOSE);
         $this->pause();
         $this->removeAllListeners();
 
@@ -137,16 +138,19 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         \restore_error_handler();
 
         if ($error !== null) {
-            $this->emit('error', array(new \RuntimeException('Unable to read from stream: ' . $error->getMessage(), 0, $error)));
+            $this->emit(
+                Event\ERROR,
+                array(new \RuntimeException('Unable to read from stream: ' . $error->getMessage(), 0, $error))
+            );
             $this->close();
             return;
         }
 
         if ($data !== '') {
-            $this->emit('data', array($data));
+            $this->emit(Event\DATA, array($data));
         } elseif (\feof($this->stream)) {
             // no data read => we reached the end and close the stream
-            $this->emit('end');
+            $this->emit(Event\END);
             $this->close();
         }
     }

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -12,19 +12,20 @@ use Evenement\EventEmitterInterface;
  * `EventEmitterInterface` which allows you to react to certain events:
  *
  * data event:
- *     The `data` event will be emitted whenever some data was read/received
- *     from this source stream.
+ *     The `React\Stream\Event\DATA` event will be emitted whenever some
+ *     data was read/received from this source stream.
  *     The event receives a single mixed argument for incoming data.
  *
  *     ```php
- *     $stream->on('data', function ($data) {
+ *     $stream->on(React\Stream\Event\DATA, function ($data) {
  *         echo $data;
  *     });
  *     ```
  *
  *     This event MAY be emitted any number of times, which may be zero times if
  *     this stream does not send any data at all.
- *     It SHOULD not be emitted after an `end` or `close` event.
+ *     It SHOULD not be emitted after an `React\Stream\Event\END` or
+ *     `React\Stream\Event\CLOSE` event.
  *
  *     The given `$data` argument may be of mixed type, but it's usually
  *     recommended it SHOULD be a `string` value or MAY use a type that allows
@@ -43,20 +44,21 @@ use Evenement\EventEmitterInterface;
  *     these low-level data chunks in order to achieve proper message framing.
  *
  * end event:
- *     The `end` event will be emitted once the source stream has successfully
- *     reached the end of the stream (EOF).
+ *     The `React\Stream\Event\END` event will be emitted once the source stream
+ *     has successfully reached the end of the stream (EOF).
  *
  *     ```php
- *     $stream->on('end', function () {
+ *     $stream->on(React\Stream\Event\END, function () {
  *         echo 'END';
  *     });
  *     ```
  *
  *     This event SHOULD be emitted once or never at all, depending on whether
  *     a successful end was detected.
- *     It SHOULD NOT be emitted after a previous `end` or `close` event.
+ *     It SHOULD NOT be emitted after a previous `React\Stream\Event\END` or
+ *     `React\Stream\Event\CLOSE` event.
  *     It MUST NOT be emitted if the stream closes due to a non-successful
- *     end, such as after a previous `error` event.
+ *     end, such as after a previous `React\Stream\Event\ERROR` event.
  *
  *     After the stream is ended, it MUST switch to non-readable mode,
  *     see also `isReadable()`.
@@ -65,9 +67,9 @@ use Evenement\EventEmitterInterface;
  *     not if the stream was interrupted by an unrecoverable error or explicitly
  *     closed. Not all streams know this concept of a "successful end".
  *     Many use-cases involve detecting when the stream closes (terminates)
- *     instead, in this case you should use the `close` event.
- *     After the stream emits an `end` event, it SHOULD usually be followed by a
- *     `close` event.
+ *     instead, in this case you should use the `React\Stream\Event\CLOSE` event.
+ *     After the stream emits an `React\Stream\Event\END` event, it SHOULD usually
+ *     be followed by a `React\Stream\Event\CLOSE` event.
  *
  *     Many common streams (such as a TCP/IP connection or a file-based stream)
  *     will emit this event if either the remote side closes the connection or
@@ -79,70 +81,75 @@ use Evenement\EventEmitterInterface;
  *     stream.
  *
  * error event:
- *     The `error` event will be emitted once a fatal error occurs, usually while
- *     trying to read from this stream.
+ *     The `React\Stream\Event\ERROR` event will be emitted once a fatal error
+ *     occurs, usually while trying to read from this stream.
  *     The event receives a single `Exception` argument for the error instance.
  *
  *     ```php
- *     $stream->on('error', function (Exception $e) {
+ *     $stream->on(React\Stream\Event\ERROR, function (Exception $e) {
  *         echo 'Error: ' . $e->getMessage() . PHP_EOL;
  *     });
  *     ```
  *
  *     This event SHOULD be emitted once the stream detects a fatal error, such
- *     as a fatal transmission error or after an unexpected `data` or premature
- *     `end` event.
- *     It SHOULD NOT be emitted after a previous `error`, `end` or `close` event.
+ *     as a fatal transmission error or after an unexpected `React\Stream\Event\DATA`
+ *     or premature `React\Stream\Event\END` event.
+ *     It SHOULD NOT be emitted after a previous `React\Stream\Event\ERROR`,
+ *     `React\Stream\Event\END` or `React\Stream\Event\CLOSE` event.
  *     It MUST NOT be emitted if this is not a fatal error condition, such as
  *     a temporary network issue that did not cause any data to be lost.
  *
  *     After the stream errors, it MUST close the stream and SHOULD thus be
- *     followed by a `close` event and then switch to non-readable mode, see
- *     also `close()` and `isReadable()`.
+ *     followed by a `React\Stream\Event\CLOSE` event and then switch to
+ *     non-readable mode, see also `close()` and `isReadable()`.
  *
  *     Many common streams (such as a TCP/IP connection or a file-based stream)
  *     only deal with data transmission and do not make assumption about data
- *     boundaries (such as unexpected `data` or premature `end` events).
+ *     boundaries (such as unexpected `React\Stream\Event\DATA` or premature
+ *     `React\Stream\Event\END` events).
  *     In other words, many lower-level protocols (such as TCP/IP) may choose
  *     to only emit this for a fatal transmission error once and will then
  *     close (terminate) the stream in response.
  *
  *     If this stream is a `DuplexStreamInterface`, you should also notice
- *     how the writable side of the stream also implements an `error` event.
+ *     how the writable side of the stream also implements an
+ *     `React\Stream\Event\ERROR` event.
  *     In other words, an error may occur while either reading or writing the
  *     stream which should result in the same error processing.
  *
  * close event:
- *     The `close` event will be emitted once the stream closes (terminates).
+ *     The `React\Stream\Event\CLOSE` event will be emitted once the stream closes (terminates).
  *
  *     ```php
- *     $stream->on('close', function () {
+ *     $stream->on(React\Stream\Event\CLOSE, function () {
  *         echo 'CLOSED';
  *     });
  *     ```
  *
  *     This event SHOULD be emitted once or never at all, depending on whether
  *     the stream ever terminates.
- *     It SHOULD NOT be emitted after a previous `close` event.
+ *     It SHOULD NOT be emitted after a previous `React\Stream\Event\CLOSE` event.
  *
  *     After the stream is closed, it MUST switch to non-readable mode,
  *     see also `isReadable()`.
  *
- *     Unlike the `end` event, this event SHOULD be emitted whenever the stream
- *     closes, irrespective of whether this happens implicitly due to an
- *     unrecoverable error or explicitly when either side closes the stream.
- *     If you only want to detect a *successful* end, you should use the `end`
- *     event instead.
+ *     Unlike the `React\Stream\Event\END` event, this event SHOULD be emitted
+ *     whenever the stream closes, irrespective of whether this happens implicitly
+ *     due to an unrecoverable error or explicitly when either side closes the stream.
+ *     If you only want to detect a *successful* end, you should use the
+ *     `React\Stream\Event\END` event instead.
  *
  *     Many common streams (such as a TCP/IP connection or a file-based stream)
  *     will likely choose to emit this event after reading a *successful* `end`
  *     event or after a fatal transmission `error` event.
  *
  *     If this stream is a `DuplexStreamInterface`, you should also notice
- *     how the writable side of the stream also implements a `close` event.
+ *     how the writable side of the stream also implements a
+ *     `React\Stream\Event\CLOSE` event.
  *     In other words, after receiving this event, the stream MUST switch into
  *     non-writable AND non-readable mode, see also `isWritable()`.
- *     Note that this event should not be confused with the `end` event.
+ *     Note that this event should not be confused with the
+ *     `React\Stream\Event\END` event.
  *
  * The event callback functions MUST be a valid `callable` that obeys strict
  * parameter definitions and MUST accept event parameters exactly as documented.
@@ -169,14 +176,14 @@ interface ReadableStreamInterface extends EventEmitterInterface
      *
      * This method can be used to check if the stream still accepts incoming
      * data events or if it is ended or closed already.
-     * Once the stream is non-readable, no further `data` or `end` events SHOULD
-     * be emitted.
+     * Once the stream is non-readable, no further `React\Stream\Event\DATA`
+     * or `React\Stream\Event\END` events SHOULD be emitted.
      *
      * ```php
      * assert($stream->isReadable() === false);
      *
-     * $stream->on('data', assertNeverCalled());
-     * $stream->on('end', assertNeverCalled());
+     * $stream->on(React\Stream\Event\DATA, assertNeverCalled());
+     * $stream->on(React\Stream\Event\END, assertNeverCalled());
      * ```
      *
      * A successfully opened stream always MUST start in readable mode.
@@ -205,18 +212,18 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * Unless otherwise noted, a successfully opened stream SHOULD NOT start
      * in paused state.
      *
-     * Once the stream is paused, no futher `data` or `end` events SHOULD
-     * be emitted.
+     * Once the stream is paused, no further `React\Stream\Event\DATA` or
+     * `React\Stream\Event\END` events SHOULD be emitted.
      *
      * ```php
      * $stream->pause();
      *
-     * $stream->on('data', assertShouldNeverCalled());
-     * $stream->on('end', assertShouldNeverCalled());
+     * $stream->on(React\Stream\Event\DATA, assertShouldNeverCalled());
+     * $stream->on(React\Stream\Event\END, assertShouldNeverCalled());
      * ```
      *
      * This method is advisory-only, though generally not recommended, the
-     * stream MAY continue emitting `data` events.
+     * stream MAY continue emitting `React\Stream\Event\DATA` events.
      *
      * You can continue processing events by calling `resume()` again.
      *
@@ -275,19 +282,21 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * ```
      *
      * By default, this will call `end()` on the destination stream once the
-     * source stream emits an `end` event. This can be disabled like this:
+     * source stream emits an `React\Stream\Event\END` event.
+     * This can be disabled like this:
      *
      * ```php
      * $source->pipe($dest, array('end' => false));
      * ```
      *
-     * Note that this only applies to the `end` event.
-     * If an `error` or explicit `close` event happens on the source stream,
-     * you'll have to manually close the destination stream:
+     * Note that this only applies to the `React\Stream\Event\END` event.
+     * If an `React\Stream\Event\ERROR` or explicit `React\Stream\Event\CLOSE`
+     * event happens on the source stream, you'll have to manually close
+     * the destination stream:
      *
      * ```php
      * $source->pipe($dest);
-     * $source->on('close', function () use ($dest) {
+     * $source->on(React\Stream\Event\CLOSE, function () use ($dest) {
      *     $dest->end('BYE!');
      * });
      * ```
@@ -316,7 +325,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * ```
      *
      * Once the pipe is set up successfully, the destination stream MUST emit
-     * a `pipe` event with this source stream an event argument.
+     * a `React\Stream\Event\PIPE` event with this source stream an event argument.
      *
      * @param WritableStreamInterface $dest
      * @param array $options
@@ -333,20 +342,21 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * $stream->close();
      * ```
      *
-     * Once the stream is closed, it SHOULD emit a `close` event.
+     * Once the stream is closed, it SHOULD emit a `React\Stream\Event\CLOSE` event.
      * Note that this event SHOULD NOT be emitted more than once, in particular
      * if this method is called multiple times.
      *
      * After calling this method, the stream MUST switch into a non-readable
      * mode, see also `isReadable()`.
-     * This means that no further `data` or `end` events SHOULD be emitted.
+     * This means that no further `React\Stream\Event\DATA` or `React\Stream\Event\END`
+     * events SHOULD be emitted.
      *
      * ```php
      * $stream->close();
      * assert($stream->isReadable() === false);
      *
-     * $stream->on('data', assertNeverCalled());
-     * $stream->on('end', assertNeverCalled());
+     * $stream->on(React\Stream\Event\DATA, assertNeverCalled());
+     * $stream->on(React\Stream\Event\END, assertNeverCalled());
      * ```
      *
      * If this stream is a `DuplexStreamInterface`, you should also notice

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -4,6 +4,7 @@ namespace React\Stream;
 
 use Evenement\EventEmitter;
 use InvalidArgumentException;
+use React\Stream\Event;
 
 /**
  * The `ThroughStream` implements the
@@ -12,7 +13,7 @@ use InvalidArgumentException;
  *
  * ```php
  * $through = new ThroughStream();
- * $through->on('data', $this->expectCallableOnceWith('hello'));
+ * $through->on(React\Stream\Event\DATA, $this->expectCallableOnceWith('hello'));
  *
  * $through->write('hello');
  * ```
@@ -46,7 +47,7 @@ use InvalidArgumentException;
  * $through = new ThroughStream(function ($data) {
  *     return json_encode($data) . PHP_EOL;
  * });
- * $through->on('data', $this->expectCallableOnceWith("[2, true]\n"));
+ * $through->on(React\Stream\Event\DATA, $this->expectCallableOnceWith("[2, true]\n"));
  *
  * $through->write(array(2, true));
  * ```
@@ -61,9 +62,9 @@ use InvalidArgumentException;
  *     }
  *     return $data;
  * });
- * $through->on('error', $this->expectCallableOnce()));
- * $through->on('close', $this->expectCallableOnce()));
- * $through->on('data', $this->expectCallableNever()));
+ * $through->on(React\Stream\Event\ERROR, $this->expectCallableOnce()));
+ * $through->on(React\Stream\Event\CLOSE, $this->expectCallableOnce()));
+ * $through->on(React\Stream\Event\DATA, $this->expectCallableNever()));
  *
  * $through->write(2);
  * ```
@@ -100,7 +101,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
     {
         if ($this->drain) {
             $this->drain = false;
-            $this->emit('drain');
+            $this->emit(Event\DRAIN);
         }
         $this->paused = false;
     }
@@ -130,14 +131,14 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
             try {
                 $data = \call_user_func($this->callback, $data);
             } catch (\Exception $e) {
-                $this->emit('error', array($e));
+                $this->emit(Event\ERROR, array($e));
                 $this->close();
 
                 return false;
             }
         }
 
-        $this->emit('data', array($data));
+        $this->emit(Event\DATA, array($data));
 
         if ($this->paused) {
             $this->drain = true;
@@ -167,7 +168,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
         $this->paused = true;
         $this->drain = false;
 
-        $this->emit('end');
+        $this->emit(Event\END);
         $this->close();
     }
 
@@ -184,7 +185,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
         $this->drain = false;
         $this->callback = null;
 
-        $this->emit('close');
+        $this->emit(Event\CLOSE);
         $this->removeAllListeners();
     }
 }

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -4,6 +4,7 @@ namespace React\Stream;
 
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
+use React\Stream\Event;
 
 final class WritableResourceStream extends EventEmitter implements WritableStreamInterface
 {
@@ -93,7 +94,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         $this->writable = false;
         $this->data = '';
 
-        $this->emit('close');
+        $this->emit(Event\CLOSE);
         $this->removeAllListeners();
 
         if (\is_resource($this->stream)) {
@@ -140,7 +141,8 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
                 );
             }
 
-            $this->emit('error', array(new \RuntimeException('Unable to write to stream: ' . ($error !== null ? $error->getMessage() : 'Unknown error'), 0, $error)));
+            $errorMessage = 'Unable to write to stream: ' . ($error !== null ? $error->getMessage() : 'Unknown error');
+            $this->emit(Event\ERROR, array(new \RuntimeException($errorMessage), 0, $error));
             $this->close();
 
             return;
@@ -151,7 +153,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 
         // buffer has been above limit and is now below limit
         if ($exceeded && !isset($this->data[$this->softLimit - 1])) {
-            $this->emit('drain');
+            $this->emit(Event\DRAIN);
         }
 
         // buffer is now completely empty => stop trying to write

--- a/src/events.php
+++ b/src/events.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace React\Stream\Event
+{
+    const CLOSE = 'close';
+
+    const DATA = 'data';
+
+    const DRAIN = 'drain';
+
+    const END = 'end';
+
+    const ERROR = 'error';
+
+    const PIPE = 'pipe';
+}

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Stream;
 
 use React\Stream\CompositeStream;
 use React\Stream\ThroughStream;
+use React\Stream\Event;
 
 /**
  * @covers React\Stream\CompositeStream
@@ -30,7 +31,7 @@ class CompositeStreamTest extends TestCase
 
         $composite = new CompositeStream($readable, $writable);
 
-        $composite->on('close', $this->expectCallableNever());
+        $composite->on(Event\CLOSE, $this->expectCallableNever());
         $composite->close();
     }
 
@@ -50,7 +51,7 @@ class CompositeStreamTest extends TestCase
 
         $composite = new CompositeStream($readable, $writable);
 
-        $composite->on('close', $this->expectCallableNever());
+        $composite->on(Event\CLOSE, $this->expectCallableNever());
         $composite->close();
     }
 
@@ -182,7 +183,7 @@ class CompositeStreamTest extends TestCase
         $writable = new ThroughStream();
 
         $composite = new CompositeStream($readable, $writable);
-        $composite->on('close', $this->expectCallableOnce());
+        $composite->on(Event\CLOSE, $this->expectCallableOnce());
 
         $readable->close();
         $writable->close();
@@ -194,7 +195,7 @@ class CompositeStreamTest extends TestCase
         $in = new ThroughStream();
 
         $composite = new CompositeStream($in, $in);
-        $composite->on('close', $this->expectCallableOnce());
+        $composite->on(Event\CLOSE, $this->expectCallableOnce());
 
         $this->assertTrue($composite->isReadable());
         $this->assertTrue($composite->isWritable());
@@ -214,11 +215,11 @@ class CompositeStreamTest extends TestCase
         $writable = new ThroughStream();
 
         $composite = new CompositeStream($readable, $writable);
-        $composite->on('data', $this->expectCallableOnce());
-        $composite->on('drain', $this->expectCallableOnce());
+        $composite->on(Event\DATA, $this->expectCallableOnce());
+        $composite->on(Event\DRAIN, $this->expectCallableOnce());
 
-        $readable->emit('data', array('foo'));
-        $writable->emit('drain');
+        $readable->emit(Event\DATA, array('foo'));
+        $writable->emit(Event\DRAIN);
     }
 
     /** @test */
@@ -241,7 +242,7 @@ class CompositeStreamTest extends TestCase
 
         $input = new ThroughStream();
         $input->pipe($composite);
-        $input->emit('data', array('foo'));
+        $input->emit(Event\DATA, array('foo'));
     }
 
     /** @test */
@@ -262,6 +263,6 @@ class CompositeStreamTest extends TestCase
             ->with('foo');
 
         $composite->pipe($output);
-        $readable->emit('data', array('foo'));
+        $readable->emit(Event\DATA, array('foo'));
     }
 }

--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -12,6 +12,7 @@ use React\EventLoop\LoopInterface;
 use React\EventLoop\LibEventLoop;
 use React\EventLoop\LibEvLoop;
 use React\EventLoop\StreamSelectLoop;
+use React\Stream\Event;
 
 class DuplexResourceStreamIntegrationTest extends TestCase
 {
@@ -73,7 +74,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $testString = str_repeat("*", $bufferSize + 1);
 
         $buffer = "";
-        $streamB->on('data', function ($data) use (&$buffer) {
+        $streamB->on(Event\DATA, function ($data) use (&$buffer) {
             $buffer .= $data;
         });
 
@@ -110,16 +111,16 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         // sending side sends and expects clean close with no errors
         $streamA->end(str_repeat('*', $size));
-        $streamA->on('close', $this->expectCallableOnce());
-        $streamA->on('error', $this->expectCallableNever());
+        $streamA->on(Event\CLOSE, $this->expectCallableOnce());
+        $streamA->on(Event\ERROR, $this->expectCallableNever());
 
         // receiving side counts bytes and expects clean close with no errors
         $received = 0;
-        $streamB->on('data', function ($chunk) use (&$received) {
+        $streamB->on(Event\DATA, function ($chunk) use (&$received) {
             $received += strlen($chunk);
         });
-        $streamB->on('close', $this->expectCallableOnce());
-        $streamB->on('error', $this->expectCallableNever());
+        $streamB->on(Event\CLOSE, $this->expectCallableOnce());
+        $streamB->on(Event\ERROR, $this->expectCallableNever());
 
         $loop->run();
 
@@ -149,7 +150,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamA->end();
 
         // streamB should not emit any data
-        $streamB->on('data', $this->expectCallableNever());
+        $streamB->on(Event\DATA, $this->expectCallableNever());
 
         $loop->run();
 
@@ -176,9 +177,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         // end streamA without writing any data
         $streamA->pause();
         $streamA->write('hello');
-        $streamA->on('close', $this->expectCallableOnce());
+        $streamA->on(Event\CLOSE, $this->expectCallableOnce());
 
-        $streamB->on('data', $this->expectCallableNever());
+        $streamB->on(Event\DATA, $this->expectCallableNever());
         $streamB->close();
 
         $loop->run();
@@ -209,9 +210,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         // end streamA without writing any data
         $streamA->pause();
         $streamA->write('hello');
-        $streamA->on('close', $this->expectCallableOnce());
+        $streamA->on(Event\CLOSE, $this->expectCallableOnce());
 
-        $streamB->on('data', $this->expectCallableNever());
+        $streamB->on(Event\DATA, $this->expectCallableNever());
         $streamB->close();
 
         $loop->run();
@@ -242,9 +243,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         // end streamA without writing any data
         $streamA->pause();
         $streamA->write('hello');
-        $streamA->on('close', $this->expectCallableOnce());
+        $streamA->on(Event\CLOSE, $this->expectCallableOnce());
 
-        $streamB->on('data', $this->expectCallableNever());
+        $streamB->on(Event\DATA, $this->expectCallableNever());
         $streamB->close();
 
         $loop->run();
@@ -265,9 +266,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $loop = $loopFactory();
 
         $stream = new ReadableResourceStream(popen('echo test', 'r'), $loop);
-        $stream->on('data', $this->expectCallableOnceWith("test\n"));
-        $stream->on('end', $this->expectCallableOnce());
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\DATA, $this->expectCallableOnceWith("test\n"));
+        $stream->on(Event\END, $this->expectCallableOnce());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $loop->run();
     }
@@ -286,12 +287,12 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream = new ReadableResourceStream(popen('echo a;sleep 0.1;echo b;sleep 0.1;echo c', 'r'), $loop);
 
         $buffer = '';
-        $stream->on('data', function ($chunk) use (&$buffer) {
+        $stream->on(Event\DATA, function ($chunk) use (&$buffer) {
             $buffer .= $chunk;
         });
 
-        $stream->on('end', $this->expectCallableOnce());
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\END, $this->expectCallableOnce());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $loop->run();
 
@@ -312,12 +313,12 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream = new ReadableResourceStream(popen('dd if=/dev/zero bs=12345 count=1234 2>&-', 'r'), $loop);
 
         $bytes = 0;
-        $stream->on('data', function ($chunk) use (&$bytes) {
+        $stream->on(Event\DATA, function ($chunk) use (&$bytes) {
             $bytes += strlen($chunk);
         });
 
-        $stream->on('end', $this->expectCallableOnce());
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\END, $this->expectCallableOnce());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $loop->run();
 
@@ -336,9 +337,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $loop = $loopFactory();
 
         $stream = new ReadableResourceStream(popen('true', 'r'), $loop);
-        $stream->on('data', $this->expectCallableNever());
-        $stream->on('end', $this->expectCallableOnce());
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\DATA, $this->expectCallableNever());
+        $stream->on(Event\END, $this->expectCallableOnce());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $loop->run();
     }

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -5,6 +5,7 @@ namespace React\Tests\Stream;
 use React\Stream\DuplexResourceStream;
 use Clue\StreamFilter as Filter;
 use React\Stream\WritableResourceStream;
+use React\Stream\Event;
 
 class DuplexResourceStreamTest extends TestCase
 {
@@ -113,8 +114,8 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
-        $conn->on('close', $this->expectCallableOnce());
-        $conn->on('end', $this->expectCallableNever());
+        $conn->on(Event\CLOSE, $this->expectCallableOnce());
+        $conn->on(Event\END, $this->expectCallableNever());
 
         $conn->close();
 
@@ -159,7 +160,7 @@ class DuplexResourceStreamTest extends TestCase
         $capturedData = null;
 
         $conn = new DuplexResourceStream($stream, $loop);
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -182,7 +183,7 @@ class DuplexResourceStreamTest extends TestCase
         $capturedData = null;
 
         $conn = new DuplexResourceStream($stream, $loop, 4321);
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -208,7 +209,7 @@ class DuplexResourceStreamTest extends TestCase
 
         $conn = new DuplexResourceStream($stream, $loop, -1);
 
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -230,7 +231,7 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
-        $conn->on('data', $this->expectCallableNever());
+        $conn->on(Event\DATA, $this->expectCallableNever());
 
         $conn->handleData($stream);
     }
@@ -392,11 +393,11 @@ class DuplexResourceStreamTest extends TestCase
         $buffer = new WritableResourceStream($stream, $loop);
         $conn = new DuplexResourceStream($stream, $loop, null, $buffer);
 
-        $conn->on('drain', $this->expectCallableOnce());
-        $conn->on('error', $this->expectCallableOnce());
+        $conn->on(Event\DRAIN, $this->expectCallableOnce());
+        $conn->on(Event\ERROR, $this->expectCallableOnce());
 
-        $buffer->emit('drain');
-        $buffer->emit('error', array(new \RuntimeException('Whoops')));
+        $buffer->emit(Event\DRAIN);
+        $buffer->emit(Event\ERROR, array(new \RuntimeException('Whoops')));
     }
 
     /**
@@ -408,8 +409,8 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
-        $conn->on('error', $this->expectCallableNever());
-        $conn->on('data', function ($data) use ($conn) {
+        $conn->on(Event\ERROR, $this->expectCallableNever());
+        $conn->on(Event\DATA, function ($data) use ($conn) {
             $conn->close();
         });
 
@@ -436,7 +437,7 @@ class DuplexResourceStreamTest extends TestCase
         $capturedData = null;
 
         $conn = new DuplexResourceStream($stream, $loop);
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -465,9 +466,9 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
-        $conn->on('data', $this->expectCallableNever());
-        $conn->on('error', $this->expectCallableOnce());
-        $conn->on('close', $this->expectCallableOnce());
+        $conn->on(Event\DATA, $this->expectCallableNever());
+        $conn->on(Event\ERROR, $this->expectCallableOnce());
+        $conn->on(Event\CLOSE, $this->expectCallableOnce());
 
         fwrite($stream, "foobar\n");
         rewind($stream);

--- a/tests/EventsBackwardsCompatibilityTest.php
+++ b/tests/EventsBackwardsCompatibilityTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace React\Tests\Stream;
+
+use React\Stream\Event;
+
+class EventsBackwardsCompatibilityTest extends TestCase
+{
+    public function eventNamesWontBreakCompatibilityProvider()
+    {
+        return array(
+            array('close', Event\CLOSE),
+            array('data', Event\DATA),
+            array('drain', Event\DRAIN),
+            array('end', Event\END),
+            array('error', Event\ERROR),
+            array('pipe', Event\PIPE),
+        );
+    }
+
+    /**
+     * @param string $expected
+     * @param string $actual
+     *
+     * @dataProvider eventNamesWontBreakCompatibilityProvider
+     */
+    public function testEventNamesWontBreakCompatibility($expected, $actual)
+    {
+        $this->assertEquals($expected, $actual, 'Event names must be compatible with previous versions.');
+    }
+}

--- a/tests/FunctionalInternetTest.php
+++ b/tests/FunctionalInternetTest.php
@@ -6,6 +6,7 @@ use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
 use React\Stream\DuplexResourceStream;
 use React\Stream\WritableResourceStream;
+use React\Stream\Event;
 
 /**
  * @group internet
@@ -21,11 +22,11 @@ class FunctionalInternetTest extends TestCase
         $stream = new DuplexResourceStream($stream, $loop);
 
         $buffer = '';
-        $stream->on('data', function ($chunk) use (&$buffer) {
+        $stream->on(Event\DATA, function ($chunk) use (&$buffer) {
             $buffer .= $chunk;
         });
 
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
 
@@ -43,11 +44,11 @@ class FunctionalInternetTest extends TestCase
         $stream = new DuplexResourceStream($stream, $loop);
 
         $buffer = '';
-        $stream->on('data', function ($chunk) use (&$buffer) {
+        $stream->on(Event\DATA, function ($chunk) use (&$buffer) {
             $buffer .= $chunk;
         });
 
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
 
@@ -65,11 +66,11 @@ class FunctionalInternetTest extends TestCase
         $stream = new DuplexResourceStream($stream, $loop);
 
         $buffer = '';
-        $stream->on('data', function ($chunk) use (&$buffer) {
+        $stream->on(Event\DATA, function ($chunk) use (&$buffer) {
             $buffer .= $chunk;
         });
 
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
 
@@ -92,11 +93,11 @@ class FunctionalInternetTest extends TestCase
         );
 
         $buffer = '';
-        $stream->on('data', function ($chunk) use (&$buffer) {
+        $stream->on(Event\DATA, function ($chunk) use (&$buffer) {
             $buffer .= $chunk;
         });
 
-        $stream->on('error', $this->expectCallableNever());
+        $stream->on(Event\ERROR, $this->expectCallableNever());
 
         $stream->write("POST /post HTTP/1.0\r\nHost: httpbin.org\r\nContent-Length: $size\r\n\r\n" . str_repeat('.', $size));
 
@@ -107,7 +108,7 @@ class FunctionalInternetTest extends TestCase
 
     private function awaitStreamClose(DuplexResourceStream $stream, LoopInterface $loop, $timeout = 10.0)
     {
-        $stream->on('close', function () use ($loop) {
+        $stream->on(Event\CLOSE, function () use ($loop) {
             $loop->stop();
         });
 

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Stream;
 
 use React\Stream\ReadableResourceStream;
 use Clue\StreamFilter as Filter;
+use React\Stream\Event;
 
 class ReadableResourceStreamTest extends TestCase
 {
@@ -99,7 +100,7 @@ class ReadableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
-        $conn->on('close', $this->expectCallableOnce());
+        $conn->on(Event\CLOSE, $this->expectCallableOnce());
 
         $conn->close();
 
@@ -112,7 +113,7 @@ class ReadableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
-        $conn->on('close', $this->expectCallableOnce());
+        $conn->on(Event\CLOSE, $this->expectCallableOnce());
 
         $conn->close();
         $conn->close();
@@ -130,7 +131,7 @@ class ReadableResourceStreamTest extends TestCase
         $capturedData = null;
 
         $conn = new ReadableResourceStream($stream, $loop);
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -153,7 +154,7 @@ class ReadableResourceStreamTest extends TestCase
         $capturedData = null;
 
         $conn = new ReadableResourceStream($stream, $loop, 4321);
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -179,7 +180,7 @@ class ReadableResourceStreamTest extends TestCase
 
         $conn = new ReadableResourceStream($stream, $loop, -1);
 
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -201,7 +202,7 @@ class ReadableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
-        $conn->on('data', $this->expectCallableNever());
+        $conn->on(Event\DATA, $this->expectCallableNever());
 
         $conn->handleData($stream);
     }
@@ -226,8 +227,8 @@ class ReadableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
-        $conn->on('error', $this->expectCallableNever());
-        $conn->on('data', function ($data) use ($conn) {
+        $conn->on(Event\ERROR, $this->expectCallableNever());
+        $conn->on(Event\DATA, function ($data) use ($conn) {
             $conn->close();
         });
 
@@ -326,7 +327,7 @@ class ReadableResourceStreamTest extends TestCase
         $capturedData = null;
 
         $conn = new ReadableResourceStream($stream, $loop);
-        $conn->on('data', function ($data) use (&$capturedData) {
+        $conn->on(Event\DATA, function ($data) use (&$capturedData) {
             $capturedData = $data;
         });
 
@@ -355,9 +356,9 @@ class ReadableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
-        $conn->on('data', $this->expectCallableNever());
-        $conn->on('error', $this->expectCallableOnce());
-        $conn->on('close', $this->expectCallableOnce());
+        $conn->on(Event\DATA, $this->expectCallableNever());
+        $conn->on(Event\ERROR, $this->expectCallableOnce());
+        $conn->on(Event\CLOSE, $this->expectCallableOnce());
 
         fwrite($stream, "foobar\n");
         rewind($stream);

--- a/tests/Stub/ReadableStreamStub.php
+++ b/tests/Stub/ReadableStreamStub.php
@@ -6,6 +6,7 @@ use Evenement\EventEmitter;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 use React\Stream\Util;
+use React\Stream\Event;
 
 class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
 {
@@ -20,19 +21,19 @@ class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
     // trigger data event
     public function write($data)
     {
-        $this->emit('data', array($data));
+        $this->emit(Event\DATA, array($data));
     }
 
     // trigger error event
     public function error($error)
     {
-        $this->emit('error', array($error));
+        $this->emit(Event\ERROR, array($error));
     }
 
     // trigger end event
     public function end()
     {
-        $this->emit('end', array());
+        $this->emit(Event\END, array());
     }
 
     public function pause()
@@ -49,7 +50,7 @@ class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
     {
         $this->readable = false;
 
-        $this->emit('close');
+        $this->emit(Event\CLOSE);
     }
 
     public function pipe(WritableStreamInterface $dest, array $options = array())

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Stream;
 
 use React\Stream\ThroughStream;
+use React\Stream\Event;
 
 /**
  * @covers React\Stream\ThroughStream
@@ -31,7 +32,7 @@ class ThroughStreamTest extends TestCase
     public function itShouldEmitAnyDataWrittenToIt()
     {
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableOnceWith('foo'));
+        $through->on(Event\DATA, $this->expectCallableOnceWith('foo'));
         $through->write('foo');
     }
 
@@ -39,7 +40,7 @@ class ThroughStreamTest extends TestCase
     public function itShouldEmitAnyDataWrittenToItPassedThruFunction()
     {
         $through = new ThroughStream('strtoupper');
-        $through->on('data', $this->expectCallableOnceWith('FOO'));
+        $through->on(Event\DATA, $this->expectCallableOnceWith('FOO'));
         $through->write('foo');
     }
 
@@ -47,7 +48,7 @@ class ThroughStreamTest extends TestCase
     public function itShouldEmitAnyDataWrittenToItPassedThruCallback()
     {
         $through = new ThroughStream('strtoupper');
-        $through->on('data', $this->expectCallableOnceWith('FOO'));
+        $through->on(Event\DATA, $this->expectCallableOnceWith('FOO'));
         $through->write('foo');
     }
 
@@ -57,10 +58,10 @@ class ThroughStreamTest extends TestCase
         $through = new ThroughStream(function () {
             throw new \RuntimeException();
         });
-        $through->on('error', $this->expectCallableOnce());
-        $through->on('close', $this->expectCallableOnce());
-        $through->on('data', $this->expectCallableNever());
-        $through->on('end', $this->expectCallableNever());
+        $through->on(Event\ERROR, $this->expectCallableOnce());
+        $through->on(Event\CLOSE, $this->expectCallableOnce());
+        $through->on(Event\DATA, $this->expectCallableNever());
+        $through->on(Event\END, $this->expectCallableNever());
 
         $through->write('foo');
 
@@ -74,10 +75,10 @@ class ThroughStreamTest extends TestCase
         $through = new ThroughStream(function () {
             throw new \RuntimeException();
         });
-        $through->on('error', $this->expectCallableOnce());
-        $through->on('close', $this->expectCallableOnce());
-        $through->on('data', $this->expectCallableNever());
-        $through->on('end', $this->expectCallableNever());
+        $through->on(Event\ERROR, $this->expectCallableOnce());
+        $through->on(Event\CLOSE, $this->expectCallableOnce());
+        $through->on(Event\DATA, $this->expectCallableNever());
+        $through->on(Event\END, $this->expectCallableNever());
 
         $through->end('foo');
 
@@ -102,7 +103,7 @@ class ThroughStreamTest extends TestCase
         $through->pause();
         $through->write('foo');
 
-        $through->on('drain', $this->expectCallableOnce());
+        $through->on(Event\DRAIN, $this->expectCallableOnce());
         $through->resume();
     }
 
@@ -110,7 +111,7 @@ class ThroughStreamTest extends TestCase
     public function itShouldReturnTrueForAnyDataWrittenToItWhenResumedAfterPause()
     {
         $through = new ThroughStream();
-        $through->on('drain', $this->expectCallableNever());
+        $through->on(Event\DRAIN, $this->expectCallableNever());
         $through->pause();
         $through->resume();
         $ret = $through->write('foo');
@@ -124,19 +125,19 @@ class ThroughStreamTest extends TestCase
         $readable = new ThroughStream();
 
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableOnceWith('foo'));
+        $through->on(Event\DATA, $this->expectCallableOnceWith('foo'));
 
         $readable->pipe($through);
-        $readable->emit('data', array('foo'));
+        $readable->emit(Event\DATA, array('foo'));
     }
 
     /** @test */
     public function endShouldEmitEndAndClose()
     {
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableNever());
-        $through->on('end', $this->expectCallableOnce());
-        $through->on('close', $this->expectCallableOnce());
+        $through->on(Event\DATA, $this->expectCallableNever());
+        $through->on(Event\END, $this->expectCallableOnce());
+        $through->on(Event\CLOSE, $this->expectCallableOnce());
         $through->end();
     }
 
@@ -144,7 +145,7 @@ class ThroughStreamTest extends TestCase
     public function endShouldCloseTheStream()
     {
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableNever());
+        $through->on(Event\DATA, $this->expectCallableNever());
         $through->end();
 
         $this->assertFalse($through->isReadable());
@@ -155,7 +156,7 @@ class ThroughStreamTest extends TestCase
     public function endShouldWriteDataBeforeClosing()
     {
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableOnceWith('foo'));
+        $through->on(Event\DATA, $this->expectCallableOnceWith('foo'));
         $through->end('foo');
 
         $this->assertFalse($through->isReadable());
@@ -166,7 +167,7 @@ class ThroughStreamTest extends TestCase
     public function endTwiceShouldOnlyEmitOnce()
     {
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableOnce('first'));
+        $through->on(Event\DATA, $this->expectCallableOnce('first'));
         $through->end('first');
         $through->end('ignored');
     }
@@ -175,7 +176,7 @@ class ThroughStreamTest extends TestCase
     public function writeAfterEndShouldReturnFalse()
     {
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableNever());
+        $through->on(Event\DATA, $this->expectCallableNever());
         $through->end();
 
         $this->assertFalse($through->write('foo'));
@@ -185,7 +186,7 @@ class ThroughStreamTest extends TestCase
     public function writeDataWillCloseStreamShouldReturnFalse()
     {
         $through = new ThroughStream();
-        $through->on('data', array($through, 'close'));
+        $through->on(Event\DATA, array($through, 'close'));
 
         $this->assertFalse($through->write('foo'));
     }
@@ -228,7 +229,7 @@ class ThroughStreamTest extends TestCase
     {
         $through = new ThroughStream();
 
-        $through->on('close', $this->expectCallableOnce());
+        $through->on(Event\CLOSE, $this->expectCallableOnce());
 
         $through->close();
 
@@ -241,7 +242,7 @@ class ThroughStreamTest extends TestCase
     {
         $through = new ThroughStream();
 
-        $through->on('close', $this->expectCallableOnce());
+        $through->on(Event\CLOSE, $this->expectCallableOnce());
 
         $through->close();
         $through->close();

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -266,9 +266,4 @@ class UtilTest extends TestCase
     {
         return $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
     }
-
-    private function notEqualTo($value)
-    {
-        return new \PHPUnit_Framework_Constraint_Not($value);
-    }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -6,6 +6,7 @@ use React\Stream\WritableResourceStream;
 use React\Stream\Util;
 use React\Stream\CompositeStream;
 use React\Stream\ThroughStream;
+use React\Stream\Event;
 
 /**
  * @covers React\Stream\Util
@@ -244,7 +245,7 @@ class UtilTest extends TestCase
 
         $writable->expects($this->once())->method('end');
 
-        $duplex->emit('end');
+        $duplex->emit(Event\END);
     }
 
     /** @test */
@@ -253,11 +254,11 @@ class UtilTest extends TestCase
         $source = new ThroughStream();
         $target = new ThroughStream();
 
-        Util::forwardEvents($source, $target, array('data'));
-        $target->on('data', $this->expectCallableOnce());
+        Util::forwardEvents($source, $target, array(Event\DATA));
+        $target->on(Event\DATA, $this->expectCallableOnce());
         $target->on('foo', $this->expectCallableNever());
 
-        $source->emit('data', array('hello'));
+        $source->emit(Event\DATA, array('hello'));
         $source->emit('foo', array('bar'));
     }
 

--- a/tests/WritableStreamResourceTest.php
+++ b/tests/WritableStreamResourceTest.php
@@ -4,6 +4,7 @@ namespace React\Tests\Stream;
 
 use Clue\StreamFilter as Filter;
 use React\Stream\WritableResourceStream;
+use React\Stream\Event;
 
 class WritableResourceStreamTest extends TestCase
 {
@@ -100,7 +101,7 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createWriteableLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', $this->expectCallableNever());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
 
         $buffer->write("foobar\n");
         rewind($stream);
@@ -148,7 +149,7 @@ class WritableResourceStreamTest extends TestCase
         $loop->preventWrites = true;
 
         $buffer = new WritableResourceStream($stream, $loop, 4);
-        $buffer->on('error', $this->expectCallableNever());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
 
         $this->assertTrue($buffer->write("foo"));
         $loop->preventWrites = false;
@@ -179,7 +180,7 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createWriteableLoopMock();
 
         $buffer = new WritableResourceStream($a, $loop, 4);
-        $buffer->on('error', $this->expectCallableOnce());
+        $buffer->on(Event\ERROR, $this->expectCallableOnce());
 
         fclose($b);
 
@@ -196,8 +197,8 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
-        $buffer->on('error', $this->expectCallableNever());
-        $buffer->on('drain', $this->expectCallableOnce());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
+        $buffer->on(Event\DRAIN, $this->expectCallableOnce());
 
         $buffer->write("foo");
         $buffer->handleWrite();
@@ -213,7 +214,7 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
-        $buffer->on('error', $this->expectCallableNever());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
 
         $buffer->once('drain', function () use ($buffer) {
             $buffer->write("bar\n");
@@ -238,7 +239,7 @@ class WritableResourceStreamTest extends TestCase
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
 
-        $buffer->on('drain', $this->expectCallableOnce());
+        $buffer->on(Event\DRAIN, $this->expectCallableOnce());
 
         $buffer->write("foo");
         $buffer->handleWrite();
@@ -255,9 +256,9 @@ class WritableResourceStreamTest extends TestCase
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
 
-        $buffer->on('drain', $this->expectCallableOnce());
+        $buffer->on(Event\DRAIN, $this->expectCallableOnce());
 
-        $buffer->on('close', $this->expectCallableNever());
+        $buffer->on(Event\CLOSE, $this->expectCallableNever());
 
         $buffer->write("foo");
         $buffer->handleWrite();
@@ -274,11 +275,11 @@ class WritableResourceStreamTest extends TestCase
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
 
-        $buffer->on('drain', function () use ($buffer) {
+        $buffer->on(Event\DRAIN, function () use ($buffer) {
             $buffer->close();
         });
 
-        $buffer->on('close', $this->expectCallableOnce());
+        $buffer->on(Event\CLOSE, $this->expectCallableOnce());
 
         $buffer->write("foo");
         $buffer->handleWrite();
@@ -293,8 +294,8 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', $this->expectCallableNever());
-        $buffer->on('close', $this->expectCallableOnce());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
+        $buffer->on(Event\CLOSE, $this->expectCallableOnce());
 
         $this->assertTrue($buffer->isWritable());
         $buffer->end();
@@ -310,8 +311,8 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', $this->expectCallableNever());
-        $buffer->on('close', $this->expectCallableNever());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
+        $buffer->on(Event\CLOSE, $this->expectCallableNever());
 
         $buffer->write('foo');
 
@@ -330,8 +331,8 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', $this->expectCallableNever());
-        $buffer->on('close', $this->expectCallableOnce());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
+        $buffer->on(Event\CLOSE, $this->expectCallableOnce());
 
         Filter\append($stream, function ($chunk) use (&$filterBuffer) {
             $filterBuffer .= $chunk;
@@ -355,8 +356,8 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', $this->expectCallableNever());
-        $buffer->on('close', $this->expectCallableNever());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
+        $buffer->on(Event\CLOSE, $this->expectCallableNever());
 
         $buffer->write('foo');
 
@@ -378,8 +379,8 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', $this->expectCallableNever());
-        $buffer->on('close', $this->expectCallableOnce());
+        $buffer->on(Event\ERROR, $this->expectCallableNever());
+        $buffer->on(Event\CLOSE, $this->expectCallableOnce());
 
         $this->assertTrue($buffer->isWritable());
         $buffer->close();
@@ -426,7 +427,7 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('close', $this->expectCallableOnce());
+        $buffer->on(Event\CLOSE, $this->expectCallableOnce());
 
         $buffer->close();
         $buffer->close();
@@ -468,7 +469,7 @@ class WritableResourceStreamTest extends TestCase
         $error = null;
 
         $buffer = new WritableResourceStream($stream, $loop);
-        $buffer->on('error', function ($message) use (&$error) {
+        $buffer->on(Event\ERROR, function ($message) use (&$error) {
             $error = $message;
         });
 
@@ -496,7 +497,7 @@ class WritableResourceStreamTest extends TestCase
         $error = null;
 
         $buffer = new WritableResourceStream($a, $loop);
-        $buffer->on('error', function($message) use (&$error) {
+        $buffer->on(Event\ERROR, function($message) use (&$error) {
             $error = $message;
         });
 


### PR DESCRIPTION
An improvement mentioned [here](https://github.com/reactphp/react/issues/394) by @michaelcullum points out using constants instead of directly using "magic" strings.

This PR updates the `react/stream` repo in order to do so and give a better insight about how it would look like.

Also fixed some typos and unused code.