### PR TITLE
Improve performance by prefixing all global functions calls with \ to skip the look up and resolve process and go straight to the global function

### DIFF
--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -37,19 +37,19 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
 
     public function __construct($stream, LoopInterface $loop, $readChunkSize = null, WritableStreamInterface $buffer = null)
     {
-        if (!is_resource($stream) || get_resource_type($stream) !== "stream") {
+        if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
         // ensure resource is opened for reading and wrting (fopen mode must contain "+")
-        $meta = stream_get_meta_data($stream);
-        if (isset($meta['mode']) && $meta['mode'] !== '' && strpos($meta['mode'], '+') === false) {
+        $meta = \stream_get_meta_data($stream);
+        if (isset($meta['mode']) && $meta['mode'] !== '' && \strpos($meta['mode'], '+') === false) {
             throw new InvalidArgumentException('Given stream resource is not opened in read and write mode');
         }
 
         // this class relies on non-blocking I/O in order to not interrupt the event loop
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
-        if (stream_set_blocking($stream, 0) !== true) {
+        if (\stream_set_blocking($stream, 0) !== true) {
             throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
         }
 
@@ -61,8 +61,8 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         // triggered), so we can ignore platforms not supporting this (HHVM).
         // Pipe streams (such as STDIN) do not seem to require this and legacy
         // PHP versions cause SEGFAULTs on unbuffered pipe streams, so skip this.
-        if (function_exists('stream_set_read_buffer') && !$this->isLegacyPipe($stream)) {
-            stream_set_read_buffer($stream, 0);
+        if (\function_exists('stream_set_read_buffer') && !$this->isLegacyPipe($stream)) {
+            \stream_set_read_buffer($stream, 0);
         }
 
         if ($buffer === null) {
@@ -140,8 +140,8 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         $this->buffer->close();
         $this->removeAllListeners();
 
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
+        if (\is_resource($this->stream)) {
+            \fclose($this->stream);
         }
     }
 
@@ -169,7 +169,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     public function handleData($stream)
     {
         $error = null;
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
+        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
             $error = new \ErrorException(
                 $errstr,
                 0,
@@ -179,9 +179,9 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
             );
         });
 
-        $data = stream_get_contents($stream, $this->bufferSize);
+        $data = \stream_get_contents($stream, $this->bufferSize);
 
-        restore_error_handler();
+        \restore_error_handler();
 
         if ($error !== null) {
             $this->emit('error', array(new \RuntimeException('Unable to read from stream: ' . $error->getMessage(), 0, $error)));
@@ -212,8 +212,8 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
      */
     private function isLegacyPipe($resource)
     {
-        if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512)) {
-            $meta = stream_get_meta_data($resource);
+        if (\PHP_VERSION_ID < 50428 || (\PHP_VERSION_ID >= 50500 && \PHP_VERSION_ID < 50512)) {
+            $meta = \stream_get_meta_data($resource);
 
             if (isset($meta['stream_type']) && $meta['stream_type'] === 'STDIO') {
                 return true;

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -40,19 +40,19 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
 
     public function __construct($stream, LoopInterface $loop, $readChunkSize = null)
     {
-        if (!is_resource($stream) || get_resource_type($stream) !== "stream") {
+        if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
         // ensure resource is opened for reading (fopen mode must contain "r" or "+")
-        $meta = stream_get_meta_data($stream);
-        if (isset($meta['mode']) && $meta['mode'] !== '' && strpos($meta['mode'], 'r') === strpos($meta['mode'], '+')) {
+        $meta = \stream_get_meta_data($stream);
+        if (isset($meta['mode']) && $meta['mode'] !== '' && \strpos($meta['mode'], 'r') === \strpos($meta['mode'], '+')) {
             throw new InvalidArgumentException('Given stream resource is not opened in read mode');
         }
 
         // this class relies on non-blocking I/O in order to not interrupt the event loop
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
-        if (stream_set_blocking($stream, 0) !== true) {
+        if (\stream_set_blocking($stream, 0) !== true) {
             throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
         }
 
@@ -64,8 +64,8 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         // triggered), so we can ignore platforms not supporting this (HHVM).
         // Pipe streams (such as STDIN) do not seem to require this and legacy
         // PHP versions cause SEGFAULTs on unbuffered pipe streams, so skip this.
-        if (function_exists('stream_set_read_buffer') && !$this->isLegacyPipe($stream)) {
-            stream_set_read_buffer($stream, 0);
+        if (\function_exists('stream_set_read_buffer') && !$this->isLegacyPipe($stream)) {
+            \stream_set_read_buffer($stream, 0);
         }
 
         $this->stream = $stream;
@@ -113,8 +113,8 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         $this->pause();
         $this->removeAllListeners();
 
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
+        if (\is_resource($this->stream)) {
+            \fclose($this->stream);
         }
     }
 
@@ -122,7 +122,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     public function handleData()
     {
         $error = null;
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
+        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
             $error = new \ErrorException(
                 $errstr,
                 0,
@@ -132,9 +132,9 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
             );
         });
 
-        $data = stream_get_contents($this->stream, $this->bufferSize);
+        $data = \stream_get_contents($this->stream, $this->bufferSize);
 
-        restore_error_handler();
+        \restore_error_handler();
 
         if ($error !== null) {
             $this->emit('error', array(new \RuntimeException('Unable to read from stream: ' . $error->getMessage(), 0, $error)));
@@ -165,8 +165,8 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
      */
     private function isLegacyPipe($resource)
     {
-        if (PHP_VERSION_ID < 50428 || (PHP_VERSION_ID >= 50500 && PHP_VERSION_ID < 50512)) {
-            $meta = stream_get_meta_data($resource);
+        if (\PHP_VERSION_ID < 50428 || (\PHP_VERSION_ID >= 50500 && \PHP_VERSION_ID < 50512)) {
+            $meta = \stream_get_meta_data($resource);
 
             if (isset($meta['stream_type']) && $meta['stream_type'] === 'STDIO') {
                 return true;

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -84,7 +84,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 
     public function __construct($callback = null)
     {
-        if ($callback !== null && !is_callable($callback)) {
+        if ($callback !== null && !\is_callable($callback)) {
             throw new InvalidArgumentException('Invalid transformation callback given');
         }
 
@@ -128,7 +128,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 
         if ($this->callback !== null) {
             try {
-                $data = call_user_func($this->callback, $data);
+                $data = \call_user_func($this->callback, $data);
             } catch (\Exception $e) {
                 $this->emit('error', array($e));
                 $this->close();

--- a/src/Util.php
+++ b/src/Util.php
@@ -68,7 +68,7 @@ final class Util
     {
         foreach ($events as $event) {
             $source->on($event, function () use ($event, $target) {
-                $target->emit($event, func_get_args());
+                $target->emit($event, \func_get_args());
             });
         }
     }

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -19,19 +19,19 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 
     public function __construct($stream, LoopInterface $loop, $writeBufferSoftLimit = null, $writeChunkSize = null)
     {
-        if (!is_resource($stream) || get_resource_type($stream) !== "stream") {
+        if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');
         }
 
         // ensure resource is opened for writing (fopen mode must contain either of "waxc+")
-        $meta = stream_get_meta_data($stream);
-        if (isset($meta['mode']) && $meta['mode'] !== '' && strtr($meta['mode'], 'waxc+', '.....') === $meta['mode']) {
+        $meta = \stream_get_meta_data($stream);
+        if (isset($meta['mode']) && $meta['mode'] !== '' && \strtr($meta['mode'], 'waxc+', '.....') === $meta['mode']) {
             throw new \InvalidArgumentException('Given stream resource is not opened in write mode');
         }
 
         // this class relies on non-blocking I/O in order to not interrupt the event loop
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
-        if (stream_set_blocking($stream, 0) !== true) {
+        if (\stream_set_blocking($stream, 0) !== true) {
             throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
         }
 
@@ -96,8 +96,8 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         $this->emit('close');
         $this->removeAllListeners();
 
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
+        if (\is_resource($this->stream)) {
+            \fclose($this->stream);
         }
     }
 
@@ -105,7 +105,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
     public function handleWrite()
     {
         $error = null;
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
+        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
             $error = array(
                 'message' => $errstr,
                 'number' => $errno,
@@ -115,12 +115,12 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         });
 
         if ($this->writeChunkSize === -1) {
-            $sent = fwrite($this->stream, $this->data);
+            $sent = \fwrite($this->stream, $this->data);
         } else {
-            $sent = fwrite($this->stream, $this->data, $this->writeChunkSize);
+            $sent = \fwrite($this->stream, $this->data, $this->writeChunkSize);
         }
 
-        restore_error_handler();
+        \restore_error_handler();
 
         // Only report errors if *nothing* could be sent.
         // Any hard (permanent) error will fail to send any data at all.
@@ -147,7 +147,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         }
 
         $exceeded = isset($this->data[$this->softLimit - 1]);
-        $this->data = (string) substr($this->data, $sent);
+        $this->data = (string) \substr($this->data, $sent);
 
         // buffer has been above limit and is now below limit
         if ($exceeded && !isset($this->data[$this->softLimit - 1])) {


### PR DESCRIPTION
The performance increase measuring using `examples/91-benchmark-throughput.php -t30` is as follows:
* `master`: 3.0GB/s
* This PR: 3.1GB/s
* Raw Linux using `cat /dev/zero | pv > /dev/null`: 3.2GB/s