### PR TITLE
Only close stream when the we reached end of the stream

### DIFF
--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -191,7 +191,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
 
         if ($data !== '') {
             $this->emit('data', array($data));
-        } else{
+        } elseif (\feof($this->stream)) {
             // no data read => we reached the end and close the stream
             $this->emit('end');
             $this->close();

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -144,7 +144,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
 
         if ($data !== '') {
             $this->emit('data', array($data));
-        } else{
+        } elseif (\feof($this->stream)) {
             // no data read => we reached the end and close the stream
             $this->emit('end');
             $this->close();

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -365,6 +365,25 @@ class ReadableResourceStreamTest extends TestCase
         $conn->handleData($stream);
     }
 
+    /**
+     * @covers React\Stream\ReadableResourceStream::handleData
+     */
+    public function testEmptyReadShouldntFcloseStream()
+    {
+        list($stream, $_) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        $loop = $this->createLoopMock();
+
+        $conn = new ReadableResourceStream($stream, $loop);
+        $conn->on('error', $this->expectCallableNever());
+        $conn->on('data', $this->expectCallableNever());
+        $conn->on('end', $this->expectCallableNever());
+
+        $conn->handleData();
+
+        fclose($stream);
+        fclose($_);
+    }
+
     private function createLoopMock()
     {
         return $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();


### PR DESCRIPTION
While working on https://github.com/reactphp/event-loop/pull/112 I ran into an issue with suddenly closed streams. Traced the issue down to `''` coming from streams when using the `ext-uv` loop. Adding this check before closing the stream resolved the issue for `ext-uv`.

Todo: 
- [x] Close stream only when reached EOF
- [x] Tests

Relates to https://github.com/reactphp/event-loop/pull/112 