### PR TITLE
Fix faulty write buffer behavior when sending large data chunks over TLS (Mac OS X only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,28 +18,17 @@ matrix:
     - php: hhvm-3.18
       install:
         - composer require phpunit/phpunit:^5 --dev --no-interaction # requires legacy phpunit
-    - os: osx
+    - name: Mac OS X
+      os: osx
       language: generic
-      php: 7.0 # just to look right on travis
-      env:
-        - PACKAGE: php70
+      before_install:
+        - curl -s http://getcomposer.org/installer | php
+        - mv composer.phar /usr/local/bin/composer
   allow_failures:
     - php: hhvm-3.18
     - os: osx
 
 install:
-  # OSX install inspired by https://github.com/kiler129/TravisCI-OSX-PHP
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then 
-      brew tap homebrew/homebrew-php 
-      echo "Installing PHP ..."
-      brew install "${PACKAGE}"
-      brew install "${PACKAGE}"-xdebug
-      brew link "${PACKAGE}"
-      echo "Installing composer ..."
-      curl -s http://getcomposer.org/installer | php
-      mv composer.phar /usr/local/bin/composer
-    fi
   - composer install --no-interaction
 
 script:


### PR DESCRIPTION
This changeset fixes faulty write buffer error handling when sending larger data chunks over TLS (HTTPS) streams as exhibited on Mac OS X only. This component will now only report a write error when *nothing* could be sent *and* and error has been reported. This indicates a fatal error condition, whereas all other cases mean that a write should be retried according to how the loop reports the stream as writable.

Supersedes / closes #149, thanks @WyriHaximus and @mpociot for reporting and filing an initial work-around.