### PR TITLE
Make tests compatible with PHP 8.2 by avoiding dynamic properties

### DIFF
--- a/tests/EnforceBlockingWrapper.php
+++ b/tests/EnforceBlockingWrapper.php
@@ -5,10 +5,12 @@ namespace React\Tests\Stream;
 /**
  * Used to test dummy stream resources that do not support setting non-blocking mode
  *
- * @link http://php.net/manual/de/class.streamwrapper.php
+ * @link https://www.php.net/manual/en/class.streamwrapper.php
  */
 class EnforceBlockingWrapper
 {
+    public $context;
+
     public function stream_open($path, $mode, $options, &$opened_path)
     {
         return true;


### PR DESCRIPTION
This simple changeset makes the test suite compatible with PHP 8.2 by avoiding dynamic properties. Note that this involves only changes to the test suite, as the project itself is already fully forward compatible. PHP 8.2 is still under active development and has not reached feature freeze yet, so I've decided against adding it to the test matrix at this point in time. After applying this changeset, the tests work just fine. Prior to this, the test output can easily be checked like this:

```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.2-rc-cli vendor/bin/phpunit
PHPUnit 9.5.20 #StandWithUkraine

.............SSS.SSS.SSS.SSS.SSS.SSS.SSS.SSS.SSS.SSS.SSS.......  63 / 179 ( 35%)

Deprecated: Creation of dynamic property React\Tests\Stream\EnforceBlockingWrapper::$context is deprecated in /data/tests/DuplexResourceStreamTest.php on line 102
..
Deprecated: Creation of dynamic property React\Tests\Stream\EnforceBlockingWrapper::$context is deprecated in /data/tests/DuplexResourceStreamTest.php on line 132
................................
Deprecated: Creation of dynamic property React\Tests\Stream\EnforceBlockingWrapper::$context is deprecated in /data/tests/ReadableResourceStreamTest.php on line 101
............................. 126 / 179 ( 70%)
................................
Deprecated: Creation of dynamic property React\Tests\Stream\EnforceBlockingWrapper::$context is deprecated in /data/tests/WritableResourceStreamTest.php on line 99
.
Deprecated: Creation of dynamic property Mock_LoopInterface_d2f295a4::$preventWrites is deprecated in /data/tests/WritableResourceStreamTest.php on line 507
...
Deprecated: Creation of dynamic property Mock_LoopInterface_d2f295a4::$preventWrites is deprecated in /data/tests/WritableResourceStreamTest.php on line 507
..
Deprecated: Creation of dynamic property Mock_LoopInterface_d2f295a4::$preventWrites is deprecated in /data/tests/WritableResourceStreamTest.php on line 507
...............           179 / 179 (100%)

Time: 00:02.744, Memory: 8.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 179, Assertions: 260, Skipped: 33.
```

Refs https://github.com/reactphp/dns/pull/186