### PR TITLE
Fix `drain` event of `ThroughStream` to handle potential race condition

### DIFF
--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -93,16 +93,19 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 
     public function pause()
     {
-        $this->paused = true;
+        // only allow pause if still readable, false otherwise
+        $this->paused = $this->readable;
     }
 
     public function resume()
     {
+        $this->paused = false;
+
+        // emit drain event if previous write was paused (throttled)
         if ($this->drain) {
             $this->drain = false;
             $this->emit('drain');
         }
-        $this->paused = false;
     }
 
     public function pipe(WritableStreamInterface $dest, array $options = array())
@@ -139,12 +142,13 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 
         $this->emit('data', array($data));
 
+        // emit drain event on next resume if currently paused (throttled)
         if ($this->paused) {
             $this->drain = true;
-            return false;
         }
 
-        return true;
+        // continue writing if still writable and not paused (throttled), false otherwise
+        return $this->writable && !$this->paused;
     }
 
     public function end($data = null)
@@ -164,7 +168,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 
         $this->readable = false;
         $this->writable = false;
-        $this->paused = true;
+        $this->paused = false;
         $this->drain = false;
 
         $this->emit('end');
@@ -179,9 +183,10 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 
         $this->readable = false;
         $this->writable = false;
-        $this->closed = true;
-        $this->paused = true;
+        $this->paused = false;
         $this->drain = false;
+
+        $this->closed = true;
         $this->callback = null;
 
         $this->emit('close');


### PR DESCRIPTION
This changeset fixes a potential race condition that may happen for the `drain` event of `ThroughStream`. This is more of an edge case when pausing/resuming/closing immediately after flushing any buffers and is unlikely to have significant impact on existing code out in the wild.

The changes look relatively simple, most of the work went into making sure this is fully covered by additional tests for such edge cases. The test suite confirms this does not affect any of the existing behavior, so this should be safe to apply.