### PR TITLE
Chore: drop $loop input parameters in favor of Loop::get()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ jobs:
           - 7.3
           - 7.2
           - 7.1
-          - 7.0
-          - 5.6
-          - 5.5
-          - 5.4
-          - 5.3
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.8",
+        "php": ">=7.1",
         "react/event-loop": "^1.2",
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0"
     },

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -100,7 +100,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     public function pause()
     {
         if ($this->listening) {
-            Loop::get()->removeReadStream($this->stream);
+            Loop::removeReadStream($this->stream);
             $this->listening = false;
         }
     }
@@ -108,7 +108,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     public function resume()
     {
         if (!$this->listening && $this->readable) {
-            Loop::get()->addReadStream($this->stream, array($this, 'handleData'));
+            Loop::addReadStream($this->stream, array($this, 'handleData'));
             $this->listening = true;
         }
     }

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -80,7 +80,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     public function pause()
     {
         if ($this->listening) {
-            Loop::get()->removeReadStream($this->stream);
+            Loop::removeReadStream($this->stream);
             $this->listening = false;
         }
     }
@@ -88,7 +88,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     public function resume()
     {
         if (!$this->listening && !$this->closed) {
-            Loop::get()->addReadStream($this->stream, array($this, 'handleData'));
+            Loop::addReadStream($this->stream, array($this, 'handleData'));
             $this->listening = true;
         }
     }

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -4,7 +4,6 @@ namespace React\Stream;
 
 use Evenement\EventEmitter;
 use React\EventLoop\Loop;
-use React\EventLoop\LoopInterface;
 use InvalidArgumentException;
 
 final class ReadableResourceStream extends EventEmitter implements ReadableStreamInterface
@@ -13,9 +12,6 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
      * @var resource
      */
     private $stream;
-
-    /** @var LoopInterface */
-    private $loop;
 
     /**
      * Controls the maximum buffer size in bytes to read at once from the stream.
@@ -40,7 +36,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     private $closed = false;
     private $listening = false;
 
-    public function __construct($stream, LoopInterface $loop = null, $readChunkSize = null)
+    public function __construct($stream, $readChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
@@ -71,7 +67,6 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         }
 
         $this->stream = $stream;
-        $this->loop = $loop ?: Loop::get();
         $this->bufferSize = ($readChunkSize === null) ? 65536 : (int)$readChunkSize;
 
         $this->resume();
@@ -85,7 +80,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     public function pause()
     {
         if ($this->listening) {
-            $this->loop->removeReadStream($this->stream);
+            Loop::get()->removeReadStream($this->stream);
             $this->listening = false;
         }
     }
@@ -93,7 +88,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     public function resume()
     {
         if (!$this->listening && !$this->closed) {
-            $this->loop->addReadStream($this->stream, array($this, 'handleData'));
+            Loop::get()->addReadStream($this->stream, array($this, 'handleData'));
             $this->listening = true;
         }
     }

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -10,9 +10,6 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 {
     private $stream;
 
-    /** @var LoopInterface */
-    private $loop;
-
     /**
      * @var int
      */
@@ -28,7 +25,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
     private $closed = false;
     private $data = '';
 
-    public function __construct($stream, LoopInterface $loop = null, $writeBufferSoftLimit = null, $writeChunkSize = null)
+    public function __construct($stream, $writeBufferSoftLimit = null, $writeChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');
@@ -47,7 +44,6 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         }
 
         $this->stream = $stream;
-        $this->loop = $loop ?: Loop::get();
         $this->softLimit = ($writeBufferSoftLimit === null) ? 65536 : (int)$writeBufferSoftLimit;
         $this->writeChunkSize = ($writeChunkSize === null) ? -1 : (int)$writeChunkSize;
     }
@@ -68,7 +64,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         if (!$this->listening && $this->data !== '') {
             $this->listening = true;
 
-            $this->loop->addWriteStream($this->stream, array($this, 'handleWrite'));
+            Loop::get()->addWriteStream($this->stream, array($this, 'handleWrite'));
         }
 
         return !isset($this->data[$this->softLimit - 1]);
@@ -97,7 +93,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 
         if ($this->listening) {
             $this->listening = false;
-            $this->loop->removeWriteStream($this->stream);
+            Loop::get()->removeWriteStream($this->stream);
         }
 
         $this->closed = true;
@@ -155,7 +151,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         if ($this->data === '') {
             // stop waiting for resource to be writable
             if ($this->listening) {
-                $this->loop->removeWriteStream($this->stream);
+                Loop::get()->removeWriteStream($this->stream);
                 $this->listening = false;
             }
 

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -64,7 +64,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         if (!$this->listening && $this->data !== '') {
             $this->listening = true;
 
-            Loop::get()->addWriteStream($this->stream, array($this, 'handleWrite'));
+            Loop::addWriteStream($this->stream, array($this, 'handleWrite'));
         }
 
         return !isset($this->data[$this->softLimit - 1]);
@@ -93,7 +93,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 
         if ($this->listening) {
             $this->listening = false;
-            Loop::get()->removeWriteStream($this->stream);
+            Loop::removeWriteStream($this->stream);
         }
 
         $this->closed = true;
@@ -151,7 +151,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         if ($this->data === '') {
             // stop waiting for resource to be writable
             if ($this->listening) {
-                Loop::get()->removeWriteStream($this->stream);
+                Loop::removeWriteStream($this->stream);
                 $this->listening = false;
             }
 

--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -8,7 +8,6 @@ use React\Stream\DuplexResourceStream;
 use React\Stream\ReadableResourceStream;
 use React\EventLoop\ExtEventLoop;
 use React\EventLoop\ExtLibeventLoop;
-use React\EventLoop\ExtLibevLoop;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\LibEventLoop;
 use React\EventLoop\LibEvLoop;

--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -130,7 +130,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('close', $this->expectCallableOnce());
         $streamB->on('error', $this->expectCallableNever());
 
-        Loop::get()->run();
+        Loop::run();
 
         $streamA->close();
         $streamB->close();
@@ -160,7 +160,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         // streamB should not emit any data
         $streamB->on('data', $this->expectCallableNever());
 
-        Loop::get()->run();
+        Loop::run();
 
         $streamA->close();
         $streamB->close();
@@ -190,7 +190,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('data', $this->expectCallableNever());
         $streamB->close();
 
-        Loop::get()->run();
+        Loop::run();
 
         $streamA->close();
         $streamB->close();
@@ -223,7 +223,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('data', $this->expectCallableNever());
         $streamB->close();
 
-        Loop::get()->run();
+        Loop::run();
 
         $streamA->close();
         $streamB->close();
@@ -256,7 +256,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('data', $this->expectCallableNever());
         $streamB->close();
 
-        Loop::get()->run();
+        Loop::run();
 
         $streamA->close();
         $streamB->close();
@@ -278,7 +278,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        Loop::get()->run();
+        Loop::run();
     }
 
     /**
@@ -302,7 +302,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        Loop::get()->run();
+        Loop::run();
 
         $this->assertEquals("a\n" . "b\n" . "c\n", $buffer);
     }
@@ -328,7 +328,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        Loop::get()->run();
+        Loop::run();
 
         $this->assertEquals(12345 * 1234, $bytes);
     }
@@ -349,7 +349,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        Loop::get()->run();
+        Loop::run();
     }
 
     /**

--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Stream;
 
 use Clue\StreamFilter as Filter;
+use React\EventLoop\Loop;
 use React\Stream\DuplexResourceStream;
 use React\Stream\ReadableResourceStream;
 use React\EventLoop\ExtEventLoop;
@@ -23,7 +24,8 @@ class DuplexResourceStreamIntegrationTest extends TestCase
                     return true;
                 },
                 function () {
-                    return new StreamSelectLoop();
+                    Loop::set(new StreamSelectLoop());
+                    return Loop::get();
                 }
             ),
             array(
@@ -31,7 +33,10 @@ class DuplexResourceStreamIntegrationTest extends TestCase
                     return function_exists('event_base_new');
                 },
                 function () {
-                    return class_exists('React\EventLoop\ExtLibeventLoop') ? new ExtLibeventLoop() : new LibEventLoop();
+                    Loop::set(
+                        class_exists('React\EventLoop\ExtLibeventLoop') ? new ExtLibeventLoop() : new LibEventLoop()
+                    );
+                    return Loop::get();
                 }
             ),
             array(
@@ -39,7 +44,10 @@ class DuplexResourceStreamIntegrationTest extends TestCase
                     return class_exists('libev\EventLoop');
                 },
                 function () {
-                    return class_exists('React\EventLoop\ExtLibevLoop') ? new ExtLibevLoop() : new LibEvLoop();
+                    Loop::set(
+                        class_exists('React\EventLoop\ExtLibeventLoop') ? new ExtLibeventLoop() : new LibEventLoop()
+                    );
+                    return Loop::get();
                 }
             ),
             array(
@@ -47,7 +55,8 @@ class DuplexResourceStreamIntegrationTest extends TestCase
                     return class_exists('EventBase') && class_exists('React\EventLoop\ExtEventLoop');
                 },
                 function () {
-                    return new ExtEventLoop();
+                    Loop::set(new ExtEventLoop());
+                    return Loop::get();
                 }
             )
         );
@@ -62,13 +71,13 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
         $bufferSize = 4096;
-        $streamA = new DuplexResourceStream($sockA, $loop, $bufferSize);
-        $streamB = new DuplexResourceStream($sockB, $loop, $bufferSize);
+        $streamA = new DuplexResourceStream($sockA, $bufferSize);
+        $streamB = new DuplexResourceStream($sockB, $bufferSize);
 
         $testString = str_repeat("*", $bufferSize + 1);
 
@@ -79,9 +88,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $streamA->write($testString);
 
-        $this->loopTick($loop);
-        $this->loopTick($loop);
-        $this->loopTick($loop);
+        $this->loopTick(Loop::get());
+        $this->loopTick(Loop::get());
+        $this->loopTick(Loop::get());
 
         $streamA->close();
         $streamB->close();
@@ -98,12 +107,12 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
-        $streamA = new DuplexResourceStream($sockA, $loop);
-        $streamB = new DuplexResourceStream($sockB, $loop);
+        $streamA = new DuplexResourceStream($sockA);
+        $streamB = new DuplexResourceStream($sockB);
 
         // limit seems to be 192 KiB
         $size = 256 * 1024;
@@ -121,7 +130,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('close', $this->expectCallableOnce());
         $streamB->on('error', $this->expectCallableNever());
 
-        $loop->run();
+        Loop::get()->run();
 
         $streamA->close();
         $streamB->close();
@@ -138,12 +147,12 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
-        $streamA = new DuplexResourceStream($sockA, $loop);
-        $streamB = new DuplexResourceStream($sockB, $loop);
+        $streamA = new DuplexResourceStream($sockA);
+        $streamB = new DuplexResourceStream($sockB);
 
         // end streamA without writing any data
         $streamA->end();
@@ -151,7 +160,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         // streamB should not emit any data
         $streamB->on('data', $this->expectCallableNever());
 
-        $loop->run();
+        Loop::get()->run();
 
         $streamA->close();
         $streamB->close();
@@ -166,12 +175,12 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
         list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
 
-        $streamA = new DuplexResourceStream($sockA, $loop);
-        $streamB = new DuplexResourceStream($sockB, $loop);
+        $streamA = new DuplexResourceStream($sockA);
+        $streamB = new DuplexResourceStream($sockB);
 
         // end streamA without writing any data
         $streamA->pause();
@@ -181,7 +190,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('data', $this->expectCallableNever());
         $streamB->close();
 
-        $loop->run();
+        Loop::get()->run();
 
         $streamA->close();
         $streamB->close();
@@ -196,15 +205,15 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
         $server = stream_socket_server('tcp://127.0.0.1:0');
 
         $client = stream_socket_client(stream_socket_get_name($server, false));
         $peer = stream_socket_accept($server);
 
-        $streamA = new DuplexResourceStream($client, $loop);
-        $streamB = new DuplexResourceStream($peer, $loop);
+        $streamA = new DuplexResourceStream($client);
+        $streamB = new DuplexResourceStream($peer);
 
         // end streamA without writing any data
         $streamA->pause();
@@ -214,7 +223,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('data', $this->expectCallableNever());
         $streamB->close();
 
-        $loop->run();
+        Loop::get()->run();
 
         $streamA->close();
         $streamB->close();
@@ -229,15 +238,15 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
         $server = stream_socket_server('tcp://127.0.0.1:0');
 
         $client = stream_socket_client(stream_socket_get_name($server, false));
         $peer = stream_socket_accept($server);
 
-        $streamA = new DuplexResourceStream($peer, $loop);
-        $streamB = new DuplexResourceStream($client, $loop);
+        $streamA = new DuplexResourceStream($peer);
+        $streamB = new DuplexResourceStream($client);
 
         // end streamA without writing any data
         $streamA->pause();
@@ -247,7 +256,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $streamB->on('data', $this->expectCallableNever());
         $streamB->close();
 
-        $loop->run();
+        Loop::get()->run();
 
         $streamA->close();
         $streamB->close();
@@ -262,14 +271,14 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('echo test', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('echo test', 'r'));
         $stream->on('data', $this->expectCallableOnceWith("test\n"));
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        $loop->run();
+        Loop::get()->run();
     }
 
     /**
@@ -281,9 +290,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('echo a;sleep 0.1;echo b;sleep 0.1;echo c', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('echo a;sleep 0.1;echo b;sleep 0.1;echo c', 'r'));
 
         $buffer = '';
         $stream->on('data', function ($chunk) use (&$buffer) {
@@ -293,7 +302,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        $loop->run();
+        Loop::get()->run();
 
         $this->assertEquals("a\n" . "b\n" . "c\n", $buffer);
     }
@@ -307,9 +316,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('dd if=/dev/zero bs=12345 count=1234 2>&-', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('dd if=/dev/zero bs=12345 count=1234 2>&-', 'r'));
 
         $bytes = 0;
         $stream->on('data', function ($chunk) use (&$bytes) {
@@ -319,7 +328,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        $loop->run();
+        Loop::get()->run();
 
         $this->assertEquals(12345 * 1234, $bytes);
     }
@@ -333,14 +342,14 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return $this->markTestSkipped('Loop implementation not available');
         }
 
-        $loop = $loopFactory();
+        $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('true', 'r'), $loop);
+        $stream = new ReadableResourceStream(popen('true', 'r'));
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
 
-        $loop->run();
+        Loop::get()->run();
     }
 
     /**
@@ -364,9 +373,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
             return '';
         }, STREAM_FILTER_READ);
 
-        $loop = $loopFactory();
+        $loopFactory();
 
-        $conn = new DuplexResourceStream($stream, $loop);
+        $conn = new DuplexResourceStream($stream);
         $conn->on('error', $this->expectCallableNever());
         $conn->on('data', $this->expectCallableNever());
         $conn->on('end', $this->expectCallableNever());

--- a/tests/FunctionalInternetTest.php
+++ b/tests/FunctionalInternetTest.php
@@ -3,7 +3,9 @@
 namespace React\Tests\Stream;
 
 use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
+use React\EventLoop\StreamSelectLoop;
 use React\Stream\DuplexResourceStream;
 use React\Stream\WritableResourceStream;
 
@@ -12,13 +14,18 @@ use React\Stream\WritableResourceStream;
  */
 class FunctionalInternetTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        Loop::set(new StreamSelectLoop());
+    }
+
     public function testUploadKilobytePlain()
     {
         $size = 1000;
         $stream = stream_socket_client('tcp://httpbin.org:80');
 
-        $loop = Factory::create();
-        $stream = new DuplexResourceStream($stream, $loop);
+        $loop = Loop::get();
+        $stream = new DuplexResourceStream($stream);
 
         $buffer = '';
         $stream->on('data', function ($chunk) use (&$buffer) {
@@ -39,8 +46,8 @@ class FunctionalInternetTest extends TestCase
         $size = 50 * 1000;
         $stream = stream_socket_client('tcp://httpbin.org:80');
 
-        $loop = Factory::create();
-        $stream = new DuplexResourceStream($stream, $loop);
+        $loop = Loop::get();
+        $stream = new DuplexResourceStream($stream);
 
         $buffer = '';
         $stream->on('data', function ($chunk) use (&$buffer) {
@@ -61,8 +68,8 @@ class FunctionalInternetTest extends TestCase
         $size = 1000;
         $stream = stream_socket_client('ssl://httpbin.org:443');
 
-        $loop = Factory::create();
-        $stream = new DuplexResourceStream($stream, $loop);
+        $loop = Loop::get();
+        $stream = new DuplexResourceStream($stream);
 
         $buffer = '';
         $stream->on('data', function ($chunk) use (&$buffer) {
@@ -92,12 +99,11 @@ class FunctionalInternetTest extends TestCase
         // We work around this by limiting the write chunk size to 8192 bytes
         // here to also support older PHP versions.
         // See https://github.com/reactphp/socket/issues/105
-        $loop = Factory::create();
+        $loop = Loop::get();
         $stream = new DuplexResourceStream(
             $stream,
-            $loop,
             null,
-            new WritableResourceStream($stream, $loop, null, 8192)
+            new WritableResourceStream($stream, null, 8192)
         );
 
         $buffer = '';

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Stream;
 
+use React\EventLoop\Loop;
 use React\Stream\WritableResourceStream;
 use React\Stream\Util;
 use React\Stream\CompositeStream;
@@ -176,7 +177,8 @@ class UtilTest extends TestCase
 
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
-        $buffer = new WritableResourceStream($stream, $loop);
+        Loop::set($loop);
+        $buffer = new WritableResourceStream($stream);
 
         $readable->pipe($buffer);
 

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -3,6 +3,7 @@
 namespace React\Tests\Stream;
 
 use Clue\StreamFilter as Filter;
+use React\EventLoop\Loop;
 use React\Stream\WritableResourceStream;
 
 class WritableResourceStreamTest extends TestCase
@@ -15,21 +16,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        new WritableResourceStream($stream, $loop);
-    }
-
-    public function testConstructWithoutLoopAssignsLoopAutomatically()
-    {
-        $resource = fopen('php://temp', 'r+');
-
-        $stream = new WritableResourceStream($resource);
-
-        $ref = new \ReflectionProperty($stream, 'loop');
-        $ref->setAccessible(true);
-        $loop = $ref->getValue($stream);
-
-        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+        new WritableResourceStream($stream);
     }
 
     /**
@@ -44,7 +33,8 @@ class WritableResourceStreamTest extends TestCase
         unlink($name);
 
         $loop = $this->createLoopMock();
-        $buffer = new WritableResourceStream($stream, $loop);
+        Loop::set($loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->close();
     }
 
@@ -55,9 +45,10 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = null;
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
         $this->setExpectedException('InvalidArgumentException');
-        new WritableResourceStream($stream, $loop);
+        new WritableResourceStream($stream);
     }
 
     /**
@@ -67,9 +58,10 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
         $this->setExpectedException('InvalidArgumentException');
-        new WritableResourceStream($stream, $loop);
+        new WritableResourceStream($stream);
     }
 
     /**
@@ -83,8 +75,9 @@ class WritableResourceStreamTest extends TestCase
         unlink($name);
 
         $loop = $this->createLoopMock();
+        Loop::set($loop);
         $this->setExpectedException('InvalidArgumentException');
-        new WritableResourceStream($stream, $loop);
+        new WritableResourceStream($stream);
     }
 
     /**
@@ -98,9 +91,10 @@ class WritableResourceStreamTest extends TestCase
 
         $stream = fopen('blocking://test', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
         $this->setExpectedException('RuntimeException');
-        new WritableResourceStream($stream, $loop);
+        new WritableResourceStream($stream);
     }
 
     /**
@@ -111,8 +105,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createWriteableLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->on('error', $this->expectCallableNever());
 
         $buffer->write("foobar\n");
@@ -128,8 +123,9 @@ class WritableResourceStreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addWriteStream')->with($this->equalTo($stream));
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
 
         $buffer->write("foobar\n");
     }
@@ -143,8 +139,9 @@ class WritableResourceStreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
         $loop->expects($this->never())->method('addWriteStream');
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
 
         $buffer->write("");
         $buffer->write(null);
@@ -168,8 +165,9 @@ class WritableResourceStreamTest extends TestCase
                     call_user_func($listener, $stream);
                 }
             }));
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop, 4);
+        $buffer = new WritableResourceStream($stream, 4);
         $buffer->on('error', $this->expectCallableNever());
 
         $this->assertTrue($buffer->write("foo"));
@@ -184,8 +182,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop, 3);
+        $buffer = new WritableResourceStream($stream, 3);
 
         $this->assertFalse($buffer->write("foo"));
     }
@@ -199,8 +198,9 @@ class WritableResourceStreamTest extends TestCase
         list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
         $loop = $this->createWriteableLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($a, $loop, 4);
+        $buffer = new WritableResourceStream($a, 4);
         $buffer->on('error', $this->expectCallableOnce());
 
         fclose($b);
@@ -216,8 +216,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop, 2);
+        $buffer = new WritableResourceStream($stream, 2);
         $buffer->on('error', $this->expectCallableNever());
         $buffer->on('drain', $this->expectCallableOnce());
 
@@ -233,8 +234,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop, 2);
+        $buffer = new WritableResourceStream($stream, 2);
         $buffer->on('error', $this->expectCallableNever());
 
         $buffer->once('drain', function () use ($buffer) {
@@ -257,8 +259,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop, 2);
+        $buffer = new WritableResourceStream($stream, 2);
 
         $buffer->on('drain', $this->expectCallableOnce());
 
@@ -274,8 +277,9 @@ class WritableResourceStreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('removeWriteStream')->with($stream);
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop, 2);
+        $buffer = new WritableResourceStream($stream, 2);
 
         $buffer->on('drain', $this->expectCallableOnce());
 
@@ -292,9 +296,10 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
         $loop->expects($this->once())->method('removeWriteStream')->with($stream);
 
-        $buffer = new WritableResourceStream($stream, $loop, 2);
+        $buffer = new WritableResourceStream($stream, 2);
 
         $buffer->on('drain', function () use ($buffer) {
             $buffer->close();
@@ -313,8 +318,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->on('error', $this->expectCallableNever());
         $buffer->on('close', $this->expectCallableOnce());
 
@@ -330,8 +336,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->on('error', $this->expectCallableNever());
         $buffer->on('close', $this->expectCallableNever());
 
@@ -354,8 +361,9 @@ class WritableResourceStreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $filterBuffer = '';
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->on('error', $this->expectCallableNever());
         $buffer->on('close', $this->expectCallableOnce());
 
@@ -379,8 +387,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->on('error', $this->expectCallableNever());
         $buffer->on('close', $this->expectCallableNever());
 
@@ -402,8 +411,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->on('error', $this->expectCallableNever());
         $buffer->on('close', $this->expectCallableOnce());
 
@@ -421,7 +431,8 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
-        $buffer = new WritableResourceStream($stream, $loop);
+        Loop::set($loop);
+        $buffer = new WritableResourceStream($stream);
 
         $loop->expects($this->once())->method('removeWriteStream')->with($stream);
 
@@ -436,7 +447,8 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
-        $buffer = new WritableResourceStream($stream, $loop);
+        Loop::set($loop);
+        $buffer = new WritableResourceStream($stream);
 
         $loop->expects($this->never())->method('removeWriteStream');
 
@@ -450,8 +462,9 @@ class WritableResourceStreamTest extends TestCase
     {
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
         $buffer->on('close', $this->expectCallableOnce());
 
         $buffer->close();
@@ -467,8 +480,9 @@ class WritableResourceStreamTest extends TestCase
         $stream = fopen('php://temp', 'r+');
         $filterBuffer = '';
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
-        $buffer = new WritableResourceStream($stream, $loop);
+        $buffer = new WritableResourceStream($stream);
 
         Filter\append($stream, function ($chunk) use (&$filterBuffer) {
             $filterBuffer .= $chunk;
@@ -491,10 +505,11 @@ class WritableResourceStreamTest extends TestCase
 
         list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
         $loop = $this->createLoopMock();
+        Loop::set($loop);
 
         $error = null;
 
-        $buffer = new WritableResourceStream($a, $loop);
+        $buffer = new WritableResourceStream($a);
         $buffer->on('error', function($message) use (&$error) {
             $error = $message;
         });


### PR DESCRIPTION
Following roadmap https://github.com/reactphp/http/issues/517