### PR TITLE
[3.x] Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -38,7 +38,13 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     private $closing = false;
     private $listening = false;
 
-    public function __construct($stream, LoopInterface $loop = null, $readChunkSize = null, WritableStreamInterface $buffer = null)
+    /**
+     * @param resource $stream
+     * @param ?LoopInterface $loop
+     * @param ?int $readChunkSize
+     * @param ?WritableStreamInterface $buffer
+     */
+    public function __construct($stream, ?LoopInterface $loop = null, $readChunkSize = null, ?WritableStreamInterface $buffer = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -40,7 +40,12 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     private $closed = false;
     private $listening = false;
 
-    public function __construct($stream, LoopInterface $loop = null, $readChunkSize = null)
+    /**
+     * @param resource $stream
+     * @param ?LoopInterface $loop
+     * @param ?int $readChunkSize
+     */
+    public function __construct($stream, ?LoopInterface $loop = null, $readChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -28,7 +28,13 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
     private $closed = false;
     private $data = '';
 
-    public function __construct($stream, LoopInterface $loop = null, $writeBufferSoftLimit = null, $writeChunkSize = null)
+    /**
+     * @param resource $stream
+     * @param ?LoopInterface $loop
+     * @param ?int $writeBufferSoftLimit
+     * @param ?int $writeChunkSize
+     */
+    public function __construct($stream, ?LoopInterface $loop = null, $writeBufferSoftLimit = null, $writeChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260.

I'm planning to add native types to the public API and introduce PHPStan in follow-up PRs.

Once merged, we should apply similar changes to all our upcoming v3 components. On top of this, we should backport similar changes to the v1 branch.

Builds on top of #175, #159 and https://github.com/reactphp/promise/pull/260