### PR TITLE
Add native types to public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ See also `pause()`.
 
 #### pipe()
 
-The `pipe(WritableStreamInterface $dest, array $options = [])` method can be used to
+The `pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface` method can be used to
 pipe all the data from this readable source into the given writable destination.
 
 Automatically sends all incoming data to the destination.

--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -27,17 +27,17 @@ final class CompositeStream extends EventEmitter implements DuplexStreamInterfac
         $this->writable->on('close', [$this, 'close']);
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->readable->isReadable();
     }
 
-    public function pause()
+    public function pause(): void
     {
         $this->readable->pause();
     }
 
-    public function resume()
+    public function resume(): void
     {
         if (!$this->writable->isWritable()) {
             return;
@@ -46,28 +46,28 @@ final class CompositeStream extends EventEmitter implements DuplexStreamInterfac
         $this->readable->resume();
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = [])
+    public function pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface
     {
         return Util::pipe($this, $dest, $options);
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->writable->isWritable();
     }
 
-    public function write($data)
+    public function write($data): bool
     {
         return $this->writable->write($data);
     }
 
-    public function end($data = null)
+    public function end($data = null): void
     {
         $this->readable->pause();
         $this->writable->end($data);
     }
 
-    public function close()
+    public function close(): void
     {
         if ($this->closed) {
             return;

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -44,7 +44,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
      * @param ?int $readChunkSize
      * @param ?WritableStreamInterface $buffer
      */
-    public function __construct($stream, ?LoopInterface $loop = null, $readChunkSize = null, ?WritableStreamInterface $buffer = null)
+    public function __construct($stream, ?LoopInterface $loop = null, ?int $readChunkSize = null, ?WritableStreamInterface $buffer = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
@@ -75,7 +75,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
 
         $this->stream = $stream;
         $this->loop = $loop ?: Loop::get();
-        $this->bufferSize = ($readChunkSize === null) ? 65536 : (int)$readChunkSize;
+        $this->bufferSize = $readChunkSize ?? 65536;
         $this->buffer = $buffer;
 
         $this->buffer->on('error', function ($error) {
@@ -91,17 +91,17 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         $this->resume();
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->readable;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->writable;
     }
 
-    public function pause()
+    public function pause(): void
     {
         if ($this->listening) {
             $this->loop->removeReadStream($this->stream);
@@ -109,7 +109,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         }
     }
 
-    public function resume()
+    public function resume(): void
     {
         if (!$this->listening && $this->readable) {
             $this->loop->addReadStream($this->stream, [$this, 'handleData']);
@@ -117,7 +117,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         }
     }
 
-    public function write($data)
+    public function write($data): bool
     {
         if (!$this->writable) {
             return false;
@@ -126,7 +126,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         return $this->buffer->write($data);
     }
 
-    public function close()
+    public function close(): void
     {
         if (!$this->writable && !$this->closing) {
             return;
@@ -147,7 +147,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         }
     }
 
-    public function end($data = null)
+    public function end($data = null): void
     {
         if (!$this->writable) {
             return;
@@ -162,7 +162,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         $this->buffer->end($data);
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = [])
+    public function pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface
     {
         return Util::pipe($this, $dest, $options);
     }

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -45,7 +45,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
      * @param ?LoopInterface $loop
      * @param ?int $readChunkSize
      */
-    public function __construct($stream, ?LoopInterface $loop = null, $readChunkSize = null)
+    public function __construct($stream, ?LoopInterface $loop = null, ?int $readChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
@@ -72,17 +72,17 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
 
         $this->stream = $stream;
         $this->loop = $loop ?: Loop::get();
-        $this->bufferSize = ($readChunkSize === null) ? 65536 : (int)$readChunkSize;
+        $this->bufferSize = $readChunkSize ?? 65536;
 
         $this->resume();
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return !$this->closed;
     }
 
-    public function pause()
+    public function pause(): void
     {
         if ($this->listening) {
             $this->loop->removeReadStream($this->stream);
@@ -90,7 +90,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         }
     }
 
-    public function resume()
+    public function resume(): void
     {
         if (!$this->listening && !$this->closed) {
             $this->loop->addReadStream($this->stream, [$this, 'handleData']);
@@ -98,12 +98,12 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         }
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = [])
+    public function pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface
     {
         return Util::pipe($this, $dest, $options);
     }
 
-    public function close()
+    public function close(): void
     {
         if ($this->closed) {
             return;

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -194,7 +194,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      *
      * @return bool
      */
-    public function isReadable();
+    public function isReadable(): bool;
 
     /**
      * Pauses reading incoming data events.
@@ -226,7 +226,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * @see self::resume()
      * @return void
      */
-    public function pause();
+    public function pause(): void;
 
     /**
      * Resumes reading incoming data events.
@@ -247,7 +247,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * @see self::pause()
      * @return void
      */
-    public function resume();
+    public function resume(): void;
 
     /**
      * Pipes all the data from this readable source into the given writable destination.
@@ -322,7 +322,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * @param array $options
      * @return WritableStreamInterface $dest stream as-is
      */
-    public function pipe(WritableStreamInterface $dest, array $options = []);
+    public function pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface;
 
     /**
      * Closes the stream (forcefully).
@@ -358,5 +358,5 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * @return void
      * @see WritableStreamInterface::close()
      */
-    public function close();
+    public function close(): void;
 }

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -82,22 +82,18 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
     private $drain = false;
     private $callback;
 
-    public function __construct($callback = null)
+    public function __construct(?callable $callback = null)
     {
-        if ($callback !== null && !\is_callable($callback)) {
-            throw new InvalidArgumentException('Invalid transformation callback given');
-        }
-
         $this->callback = $callback;
     }
 
-    public function pause()
+    public function pause(): void
     {
         // only allow pause if still readable, false otherwise
         $this->paused = $this->readable;
     }
 
-    public function resume()
+    public function resume(): void
     {
         $this->paused = false;
 
@@ -108,22 +104,22 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
         }
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = [])
+    public function pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface
     {
         return Util::pipe($this, $dest, $options);
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->readable;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->writable;
     }
 
-    public function write($data)
+    public function write($data): bool
     {
         if (!$this->writable) {
             return false;
@@ -151,7 +147,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
         return $this->writable && !$this->paused;
     }
 
-    public function end($data = null)
+    public function end($data = null): void
     {
         if (!$this->writable) {
             return;
@@ -175,7 +171,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
         $this->close();
     }
 
-    public function close()
+    public function close(): void
     {
         if ($this->closed) {
             return;

--- a/src/Util.php
+++ b/src/Util.php
@@ -13,7 +13,7 @@ final class Util
      * @return WritableStreamInterface $dest stream as-is
      * @see ReadableStreamInterface::pipe() for more details
      */
-    public static function pipe(ReadableStreamInterface $source, WritableStreamInterface $dest, array $options = [])
+    public static function pipe(ReadableStreamInterface $source, WritableStreamInterface $dest, array $options = []): WritableStreamInterface
     {
         // source not readable => NO-OP
         if (!$source->isReadable()) {
@@ -64,7 +64,13 @@ final class Util
         return $dest;
     }
 
-    public static function forwardEvents($source, $target, array $events)
+    /**
+     * @param ReadableStreamInterface|WritableStreamInterface $source
+     * @param ReadableStreamInterface|WritableStreamInterface $target
+     * @param string[] $events
+     * @return void
+     */
+    public static function forwardEvents($source, $target, array $events): void
     {
         foreach ($events as $event) {
             $source->on($event, function () use ($event, $target) {

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -34,7 +34,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
      * @param ?int $writeBufferSoftLimit
      * @param ?int $writeChunkSize
      */
-    public function __construct($stream, ?LoopInterface $loop = null, $writeBufferSoftLimit = null, $writeChunkSize = null)
+    public function __construct($stream, ?LoopInterface $loop = null, ?int $writeBufferSoftLimit = null, ?int $writeChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');
@@ -54,16 +54,16 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
 
         $this->stream = $stream;
         $this->loop = $loop ?: Loop::get();
-        $this->softLimit = ($writeBufferSoftLimit === null) ? 65536 : (int)$writeBufferSoftLimit;
-        $this->writeChunkSize = ($writeChunkSize === null) ? -1 : (int)$writeChunkSize;
+        $this->softLimit = $writeBufferSoftLimit ?? 65536;
+        $this->writeChunkSize = $writeChunkSize ?? -1;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->writable;
     }
 
-    public function write($data)
+    public function write($data): bool
     {
         if (!$this->writable) {
             return false;
@@ -80,7 +80,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         return !isset($this->data[$this->softLimit - 1]);
     }
 
-    public function end($data = null)
+    public function end($data = null): void
     {
         if (null !== $data) {
             $this->write($data);
@@ -95,7 +95,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         }
     }
 
-    public function close()
+    public function close(): void
     {
         if ($this->closed) {
             return;

--- a/src/WritableStreamInterface.php
+++ b/src/WritableStreamInterface.php
@@ -170,7 +170,7 @@ interface WritableStreamInterface extends EventEmitterInterface
      *
      * @return bool
      */
-    public function isWritable();
+    public function isWritable(): bool;
 
     /**
      * Write some data into the stream.
@@ -219,7 +219,7 @@ interface WritableStreamInterface extends EventEmitterInterface
      * @param mixed|string $data
      * @return bool
      */
-    public function write($data);
+    public function write($data): bool;
 
     /**
      * Successfully ends the stream (after optionally sending some final data).
@@ -292,7 +292,7 @@ interface WritableStreamInterface extends EventEmitterInterface
      * @param mixed|string|null $data
      * @return void
      */
-    public function end($data = null);
+    public function end($data = null): void;
 
     /**
      * Closes the stream (forcefully).
@@ -343,5 +343,5 @@ interface WritableStreamInterface extends EventEmitterInterface
      * @return void
      * @see ReadableStreamInterface::close()
      */
-    public function close();
+    public function close(): void;
 }

--- a/tests/Stub/ReadableStreamStub.php
+++ b/tests/Stub/ReadableStreamStub.php
@@ -12,7 +12,7 @@ class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
     public $readable = true;
     public $paused = false;
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
@@ -35,24 +35,24 @@ class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
         $this->emit('end', []);
     }
 
-    public function pause()
+    public function pause(): void
     {
         $this->paused = true;
     }
 
-    public function resume()
+    public function resume(): void
     {
         $this->paused = false;
     }
 
-    public function close()
+    public function close(): void
     {
         $this->readable = false;
 
         $this->emit('close');
     }
 
-    public function pipe(WritableStreamInterface $dest, array $options = [])
+    public function pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface
     {
         Util::pipe($this, $dest, $options);
 

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -10,15 +10,6 @@ use React\Stream\WritableStreamInterface;
  */
 class ThroughStreamTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function itShouldRejectInvalidCallback()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        new ThroughStream(123);
-    }
-
     /** @test */
     public function itShouldReturnTrueForAnyDataWrittenToIt()
     {


### PR DESCRIPTION
This changeset adds native types to the public API as discussed in #173.

Once merged, I'm planning to add PHPStan in a follow-up PR which would take advantage of these types.

Builds on top of #177, #175 and https://github.com/reactphp/cache/pull/60