### PR TITLE
[1.x] Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -38,7 +38,13 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     private $closing = false;
     private $listening = false;
 
-    public function __construct($stream, LoopInterface $loop = null, $readChunkSize = null, WritableStreamInterface $buffer = null)
+    /**
+     * @param resource $stream
+     * @param ?LoopInterface $loop
+     * @param ?int $readChunkSize
+     * @param ?WritableStreamInterface $buffer
+     */
+    public function __construct($stream, $loop = null, $readChunkSize = null, $buffer = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
@@ -54,6 +60,13 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
         if ($buffer !== null && !$buffer instanceof WritableResourceStream && \stream_set_blocking($stream, false) !== true) {
             throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
+        }
+
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+        if ($buffer !== null && !$buffer instanceof WritableStreamInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #4 ($buffer) expected null|React\Stream\WritableStreamInterface');
         }
 
         // Use unbuffered read operations on the underlying stream resource.

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -40,7 +40,12 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     private $closed = false;
     private $listening = false;
 
-    public function __construct($stream, LoopInterface $loop = null, $readChunkSize = null)
+    /**
+     * @param resource $stream
+     * @param ?LoopInterface $loop
+     * @param ?int $readChunkSize
+     */
+    public function __construct($stream, $loop = null, $readChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
              throw new InvalidArgumentException('First parameter must be a valid stream resource');
@@ -56,6 +61,10 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
         if (\stream_set_blocking($stream, false) !== true) {
             throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
+        }
+
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
         }
 
         // Use unbuffered read operations on the underlying stream resource.

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -28,7 +28,13 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
     private $closed = false;
     private $data = '';
 
-    public function __construct($stream, LoopInterface $loop = null, $writeBufferSoftLimit = null, $writeChunkSize = null)
+    /**
+     * @param resource $stream
+     * @param ?LoopInterface $loop
+     * @param ?int $writeBufferSoftLimit
+     * @param ?int $writeChunkSize
+     */
+    public function __construct($stream, $loop = null, $writeBufferSoftLimit = null, $writeChunkSize = null)
     {
         if (!\is_resource($stream) || \get_resource_type($stream) !== "stream") {
             throw new \InvalidArgumentException('First parameter must be a valid stream resource');
@@ -44,6 +50,10 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         // e.g. pipes on Windows do not support this: https://bugs.php.net/bug.php?id=47918
         if (\stream_set_blocking($stream, false) !== true) {
             throw new \RuntimeException('Unable to set stream resource to non-blocking mode');
+        }
+
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
         }
 
         $this->stream = $stream;

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -106,6 +106,22 @@ class DuplexResourceStreamTest extends TestCase
         new DuplexResourceStream($stream, $loop);
     }
 
+    public function testContructorThrowsExceptionForInvalidLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+        new DuplexResourceStream($stream, 42);
+    }
+
+    public function testContructorThrowsExceptionForInvalidBuffer()
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        $this->setExpectedException('InvalidArgumentException', 'Argument #4 ($buffer) expected null|React\Stream\WritableStreamInterface');
+        new DuplexResourceStream($stream, null, null, 42);
+    }
+
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      * @doesNotPerformAssertions

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -105,6 +105,13 @@ class ReadableResourceStreamTest extends TestCase
         new ReadableResourceStream($stream, $loop);
     }
 
+    public function testContructorThrowsExceptionForInvalidLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+        new ReadableResourceStream($stream, 42);
+    }
 
     public function testCloseShouldEmitCloseEvent()
     {

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -103,6 +103,14 @@ class WritableResourceStreamTest extends TestCase
         new WritableResourceStream($stream, $loop);
     }
 
+    public function testContructorThrowsExceptionForInvalidLoop()
+    {
+        $stream = fopen('php://temp', 'r+');
+
+        $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($loop) expected null|React\EventLoop\LoopInterface');
+        new WritableResourceStream($stream, 42);
+    }
+
     /**
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite


### PR DESCRIPTION
This changeset backports #177 from `3.x` to `1.x` to improve PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #177, #172 and #159