### PR TITLE
Add PHPStan to test environment with `max` level

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.github/ export-ignore
 /.gitignore export-ignore
 /examples/ export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore
 /phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,26 @@ jobs:
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
       - run: time php examples/91-benchmark-throughput.php
+
+  PHPStan:
+    name: PHPStan (PHP ${{ matrix.php }})
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php:
+          - 8.3
+          - 8.2
+          - 8.1
+          - 8.0
+          - 7.4
+          - 7.3
+          - 7.2
+          - 7.1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - run: composer install
+      - run: vendor/bin/phpstan

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ from this source stream.
 The event receives a single mixed argument for incoming data.
 
 ```php
-$stream->on('data', function ($data) {
+$stream->on('data', function (mixed $data): void {
     echo $data;
 });
 ```
@@ -142,7 +142,7 @@ The `end` event will be emitted once the source stream has successfully
 reached the end of the stream (EOF).
 
 ```php
-$stream->on('end', function () {
+$stream->on('end', function (): void {
     echo 'END';
 });
 ```
@@ -180,7 +180,7 @@ trying to read from this stream.
 The event receives a single `Exception` argument for the error instance.
 
 ```php
-$server->on('error', function (Exception $e) {
+$server->on('error', function (Exception $e): void {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 ```
@@ -213,7 +213,7 @@ stream which should result in the same error processing.
 The `close` event will be emitted once the stream closes (terminates).
 
 ```php
-$stream->on('close', function () {
+$stream->on('close', function (): void {
     echo 'CLOSED';
 });
 ```
@@ -312,7 +312,7 @@ Re-attach the data source after a previous `pause()`.
 ```php
 $stream->pause();
 
-Loop::addTimer(1.0, function () use ($stream) {
+Loop::addTimer(1.0, function () use ($stream): void {
     $stream->resume();
 });
 ```
@@ -362,7 +362,7 @@ you'll have to manually close the destination stream:
 
 ```php
 $source->pipe($dest);
-$source->on('close', function () use ($dest) {
+$source->on('close', function () use ($dest): void {
     $dest->end('BYE!');
 });
 ```
@@ -456,7 +456,7 @@ The `drain` event will be emitted whenever the write buffer became full
 previously and is now ready to accept more data.
 
 ```php
-$stream->on('drain', function () use ($stream) {
+$stream->on('drain', function () use ($stream): void {
     echo 'Stream is now ready to accept more data';
 });
 ```
@@ -478,11 +478,11 @@ The event receives a single `ReadableStreamInterface` argument for the
 source stream.
 
 ```php
-$stream->on('pipe', function (ReadableStreamInterface $source) use ($stream) {
+$stream->on('pipe', function (ReadableStreamInterface $source) use ($stream): void {
     echo 'Now receiving piped data';
 
     // explicitly close target if source emits an error
-    $source->on('error', function () use ($stream) {
+    $source->on('error', function () use ($stream): void {
         $stream->close();
     });
 });
@@ -506,7 +506,7 @@ trying to write to this stream.
 The event receives a single `Exception` argument for the error instance.
 
 ```php
-$stream->on('error', function (Exception $e) {
+$stream->on('error', function (Exception $e): void {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 ```
@@ -536,7 +536,7 @@ stream which should result in the same error processing.
 The `close` event will be emitted once the stream closes (terminates).
 
 ```php
-$stream->on('close', function () {
+$stream->on('close', function (): void {
     echo 'CLOSED';
 });
 ```
@@ -746,7 +746,7 @@ stream in order to stop waiting for the stream to flush its final data.
 
 ```php
 $stream->end();
-Loop::addTimer(1.0, function () use ($stream) {
+Loop::addTimer(1.0, function () use ($stream): void {
     $stream->close();
 });
 ```
@@ -831,10 +831,10 @@ readable mode or a stream such as `STDIN`:
 
 ```php
 $stream = new ReadableResourceStream(STDIN);
-$stream->on('data', function ($chunk) {
+$stream->on('data', function (string $chunk): void {
     echo $chunk;
 });
-$stream->on('end', function () {
+$stream->on('end', function (): void {
     echo 'END';
 });
 ```
@@ -1121,7 +1121,7 @@ used to convert data, for example for transforming any structured data into
 a newline-delimited JSON (NDJSON) stream like this:
 
 ```php
-$through = new ThroughStream(function ($data) {
+$through = new ThroughStream(function (mixed $data): string {
     return json_encode($data) . PHP_EOL;
 });
 $through->on('data', $this->expectCallableOnceWith("[2, true]\n"));
@@ -1133,7 +1133,7 @@ The callback function is allowed to throw an `Exception`. In this case,
 the stream will emit an `error` event and then [`close()`](#close-1) the stream.
 
 ```php
-$through = new ThroughStream(function ($data) {
+$through = new ThroughStream(function (mixed $data): string {
     if (!is_string($data)) {
         throw new \UnexpectedValueException('Only strings allowed');
     }
@@ -1164,7 +1164,7 @@ $stdout = new WritableResourceStream(STDOUT);
 
 $stdio = new CompositeStream($stdin, $stdout);
 
-$stdio->on('data', function ($chunk) use ($stdio) {
+$stdio->on('data', function (string $chunk) use ($stdio): void {
     $stdio->write('You said: ' . $chunk);
 });
 ```
@@ -1243,7 +1243,7 @@ If you do not want to run these, they can simply be skipped like this:
 vendor/bin/phpunit --exclude-group internet
 ```
 
-On top of this, we use PHPStan on level 5 to ensure type safety across the project:
+On top of this, we use PHPStan on max level to ensure type safety across the project:
 
 ```bash
 vendor/bin/phpstan

--- a/README.md
+++ b/README.md
@@ -1243,6 +1243,12 @@ If you do not want to run these, they can simply be skipped like this:
 vendor/bin/phpunit --exclude-group internet
 ```
 
+On top of this, we use PHPStan on level 5 to ensure type safety across the project:
+
+```bash
+vendor/bin/phpstan
+```
+
 ## License
 
 MIT, see [LICENSE file](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,9 @@
         "evenement/evenement": "^3.0 || ^2.0 || ^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^7.5",
-        "clue/stream-filter": "~1.2"
+        "clue/stream-filter": "^1.2",
+        "phpstan/phpstan": "1.11.1 || 1.4.10",
+        "phpunit/phpunit": "^9.6 || ^7.5"
     },
     "autoload": {
         "psr-4": {

--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -26,10 +26,10 @@ if (!$resource) {
 
 $stream = new DuplexResourceStream($resource);
 
-$stream->on('data', function ($chunk) {
+$stream->on('data', function (string $chunk): void {
     echo $chunk;
 });
-$stream->on('close', function () {
+$stream->on('close', function (): void {
     echo '[CLOSED]' . PHP_EOL;
 });
 

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -26,10 +26,10 @@ if (!$resource) {
 
 $stream = new DuplexResourceStream($resource);
 
-$stream->on('data', function ($chunk) {
+$stream->on('data', function (string $chunk): void {
     echo $chunk;
 });
-$stream->on('close', function () {
+$stream->on('close', function (): void {
     echo '[CLOSED]' . PHP_EOL;
 });
 

--- a/examples/91-benchmark-throughput.php
+++ b/examples/91-benchmark-throughput.php
@@ -22,8 +22,11 @@ if (DIRECTORY_SEPARATOR === '\\') {
 
 $args = getopt('i:o:t:');
 $if = $args['i'] ?? '/dev/zero';
+assert(is_string($if));
 $of = $args['o'] ?? '/dev/null';
+assert(is_string($of));
 $t  = $args['t'] ?? 1;
+assert(is_numeric($t));
 
 // passing file descriptors requires mapping paths (https://bugs.php.net/bug.php?id=53465)
 $if = str_replace('/dev/fd/', 'php://fd/', $if);
@@ -38,18 +41,21 @@ $info->write('piping from ' . $if . ' to ' . $of . ' (for max ' . $t . ' second(
 
 // setup input and output streams and pipe inbetween
 $fh = fopen($if, 'r');
+assert(is_resource($fh));
+$fo = fopen($of, 'w');
+assert(is_resource($fo));
 $in = new React\Stream\ReadableResourceStream($fh);
-$out = new React\Stream\WritableResourceStream(fopen($of, 'w'));
+$out = new React\Stream\WritableResourceStream($fo);
 $in->pipe($out);
 
 // stop input stream in $t seconds
 $start = microtime(true);
-$timeout = Loop::addTimer($t, function () use ($in) {
+$timeout = Loop::addTimer((float) $t, function () use ($in): void {
     $in->close();
 });
 
 // print stream position once stream closes
-$in->on('close', function () use ($fh, $start, $timeout, $info) {
+$in->on('close', function () use ($fh, $start, $timeout, $info): void {
     $t = microtime(true) - $start;
     Loop::cancelTimer($timeout);
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: max
 
     paths:
         - examples/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+    level: 5
+
+    paths:
+        - examples/
+        - src/
+        - tests/

--- a/src/CompositeStream.php
+++ b/src/CompositeStream.php
@@ -6,8 +6,13 @@ use Evenement\EventEmitter;
 
 final class CompositeStream extends EventEmitter implements DuplexStreamInterface
 {
+    /** @var ReadableStreamInterface */
     private $readable;
+
+    /** @var WritableStreamInterface */
     private $writable;
+
+    /** @var bool */
     private $closed = false;
 
     public function __construct(ReadableStreamInterface $readable, WritableStreamInterface $writable)

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -171,7 +171,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
     public function handleData($stream)
     {
         $error = null;
-        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
+        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error): bool {
             $error = new \ErrorException(
                 $errstr,
                 0,
@@ -179,6 +179,7 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
                 $errfile,
                 $errline
             );
+            return true;
         });
 
         $data = \stream_get_contents($stream, $this->bufferSize);

--- a/src/DuplexResourceStream.php
+++ b/src/DuplexResourceStream.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 
 final class DuplexResourceStream extends EventEmitter implements DuplexStreamInterface
 {
+    /** @var resource */
     private $stream;
 
     /** @var LoopInterface */
@@ -31,11 +32,20 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
      * @var int
      */
     private $bufferSize;
+
+    /** @var WritableStreamInterface */
     private $buffer;
 
+    /** @var bool */
     private $readable = true;
+
+    /** @var bool */
     private $writable = true;
+
+    /** @var bool */
     private $closing = false;
+
+    /** @var bool */
     private $listening = false;
 
     /**
@@ -78,13 +88,13 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         $this->bufferSize = $readChunkSize ?? 65536;
         $this->buffer = $buffer;
 
-        $this->buffer->on('error', function ($error) {
+        $this->buffer->on('error', function (\Exception $error): void {
             $this->emit('error', [$error]);
         });
 
         $this->buffer->on('close', [$this, 'close']);
 
-        $this->buffer->on('drain', function () {
+        $this->buffer->on('drain', function (): void {
             $this->emit('drain');
         });
 
@@ -167,11 +177,14 @@ final class DuplexResourceStream extends EventEmitter implements DuplexStreamInt
         return Util::pipe($this, $dest, $options);
     }
 
-    /** @internal */
-    public function handleData($stream)
+    /**
+     * @internal
+     * @param resource $stream
+     */
+    public function handleData($stream): void
     {
         $error = null;
-        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error): bool {
+        \set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline) use (&$error): bool {
             $error = new \ErrorException(
                 $errstr,
                 0,

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -37,7 +37,10 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
      */
     private $bufferSize;
 
+    /** @var bool */
     private $closed = false;
+
+    /** @var bool */
     private $listening = false;
 
     /**
@@ -121,10 +124,10 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     }
 
     /** @internal */
-    public function handleData()
+    public function handleData(): void
     {
         $error = null;
-        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error): bool {
+        \set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline) use (&$error): bool {
             $error = new \ErrorException(
                 $errstr,
                 0,

--- a/src/ReadableResourceStream.php
+++ b/src/ReadableResourceStream.php
@@ -124,7 +124,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
     public function handleData()
     {
         $error = null;
-        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error) {
+        \set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$error): bool {
             $error = new \ErrorException(
                 $errstr,
                 0,
@@ -132,6 +132,7 @@ final class ReadableResourceStream extends EventEmitter implements ReadableStrea
                 $errfile,
                 $errline
             );
+            return true;
         });
 
         $data = \stream_get_contents($this->stream, $this->bufferSize);

--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -17,7 +17,7 @@ use Evenement\EventEmitterInterface;
  *     The event receives a single mixed argument for incoming data.
  *
  *     ```php
- *     $stream->on('data', function ($data) {
+ *     $stream->on('data', function (mixed $data): void {
  *         echo $data;
  *     });
  *     ```
@@ -47,7 +47,7 @@ use Evenement\EventEmitterInterface;
  *     reached the end of the stream (EOF).
  *
  *     ```php
- *     $stream->on('end', function () {
+ *     $stream->on('end', function (): void {
  *         echo 'END';
  *     });
  *     ```
@@ -84,7 +84,7 @@ use Evenement\EventEmitterInterface;
  *     The event receives a single `Exception` argument for the error instance.
  *
  *     ```php
- *     $stream->on('error', function (Exception $e) {
+ *     $stream->on('error', function (Exception $e): void {
  *         echo 'Error: ' . $e->getMessage() . PHP_EOL;
  *     });
  *     ```
@@ -116,7 +116,7 @@ use Evenement\EventEmitterInterface;
  *     The `close` event will be emitted once the stream closes (terminates).
  *
  *     ```php
- *     $stream->on('close', function () {
+ *     $stream->on('close', function (): void {
  *         echo 'CLOSED';
  *     });
  *     ```
@@ -236,7 +236,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * ```php
      * $stream->pause();
      *
-     * Loop::addTimer(1.0, function () use ($stream) {
+     * Loop::addTimer(1.0, function () use ($stream): void {
      *     $stream->resume();
      * });
      * ```
@@ -287,7 +287,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      *
      * ```php
      * $source->pipe($dest);
-     * $source->on('close', function () use ($dest) {
+     * $source->on('close', function () use ($dest): void {
      *     $dest->end('BYE!');
      * });
      * ```
@@ -319,7 +319,7 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * a `pipe` event with this source stream an event argument.
      *
      * @param WritableStreamInterface $dest
-     * @param array $options
+     * @param array{end?:bool} $options
      * @return WritableStreamInterface $dest stream as-is
      */
     public function pipe(WritableStreamInterface $dest, array $options = []): WritableStreamInterface;

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -3,7 +3,6 @@
 namespace React\Stream;
 
 use Evenement\EventEmitter;
-use InvalidArgumentException;
 
 /**
  * The `ThroughStream` implements the
@@ -43,7 +42,7 @@ use InvalidArgumentException;
  * a newline-delimited JSON (NDJSON) stream like this:
  *
  * ```php
- * $through = new ThroughStream(function ($data) {
+ * $through = new ThroughStream(function (mixed $data): string {
  *     return json_encode($data) . PHP_EOL;
  * });
  * $through->on('data', $this->expectCallableOnceWith("[2, true]\n"));
@@ -55,7 +54,7 @@ use InvalidArgumentException;
  * the stream will emit an `error` event and then [`close()`](#close-1) the stream.
  *
  * ```php
- * $through = new ThroughStream(function ($data) {
+ * $through = new ThroughStream(function (mixed $data): string {
  *     if (!is_string($data)) {
  *         throw new \UnexpectedValueException('Only strings allowed');
  *     }
@@ -75,13 +74,27 @@ use InvalidArgumentException;
  */
 final class ThroughStream extends EventEmitter implements DuplexStreamInterface
 {
+    /** @var bool */
     private $readable = true;
+
+    /** @var bool */
     private $writable = true;
+
+    /** @var bool */
     private $closed = false;
+
+    /** @var bool */
     private $paused = false;
+
+    /** @var bool */
     private $drain = false;
+
+    /** @var ?callable */
     private $callback;
 
+    /**
+     * @param ?callable $callback
+     */
     public function __construct(?callable $callback = null)
     {
         $this->callback = $callback;

--- a/src/ThroughStream.php
+++ b/src/ThroughStream.php
@@ -144,6 +144,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
         }
 
         // continue writing if still writable and not paused (throttled), false otherwise
+        // @phpstan-ignore-next-line (may be false when write() causes stream to close)
         return $this->writable && !$this->paused;
     }
 
@@ -157,6 +158,7 @@ final class ThroughStream extends EventEmitter implements DuplexStreamInterface
             $this->write($data);
 
             // return if write() already caused the stream to close
+            // @phpstan-ignore-next-line (may be false when write() causes stream to close)
             if (!$this->writable) {
                 return;
             }

--- a/src/Util.php
+++ b/src/Util.php
@@ -9,7 +9,7 @@ final class Util
      *
      * @param ReadableStreamInterface $source
      * @param WritableStreamInterface $dest
-     * @param array $options
+     * @param array{end?:bool} $options
      * @return WritableStreamInterface $dest stream as-is
      * @see ReadableStreamInterface::pipe() for more details
      */
@@ -30,33 +30,33 @@ final class Util
         $dest->emit('pipe', [$source]);
 
         // forward all source data events as $dest->write()
-        $source->on('data', $dataer = function ($data) use ($source, $dest) {
+        $source->on('data', $dataer = function ($data) use ($source, $dest): void {
             $feedMore = $dest->write($data);
 
             if (false === $feedMore) {
                 $source->pause();
             }
         });
-        $dest->on('close', function () use ($source, $dataer) {
+        $dest->on('close', function () use ($source, $dataer): void {
             $source->removeListener('data', $dataer);
             $source->pause();
         });
 
         // forward destination drain as $source->resume()
-        $dest->on('drain', $drainer = function () use ($source) {
+        $dest->on('drain', $drainer = function () use ($source): void {
             $source->resume();
         });
-        $source->on('close', function () use ($dest, $drainer) {
+        $source->on('close', function () use ($dest, $drainer): void {
             $dest->removeListener('drain', $drainer);
         });
 
         // forward end event from source as $dest->end()
         $end = isset($options['end']) ? $options['end'] : true;
         if ($end) {
-            $source->on('end', $ender = function () use ($dest) {
+            $source->on('end', $ender = function () use ($dest): void {
                 $dest->end();
             });
-            $dest->on('close', function () use ($source, $ender) {
+            $dest->on('close', function () use ($source, $ender): void {
                 $source->removeListener('end', $ender);
             });
         }
@@ -73,7 +73,7 @@ final class Util
     public static function forwardEvents($source, $target, array $events): void
     {
         foreach ($events as $event) {
-            $source->on($event, function () use ($event, $target) {
+            $source->on($event, function () use ($event, $target): void {
                 $target->emit($event, \func_get_args());
             });
         }

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -122,8 +122,9 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
     public function handleWrite()
     {
         $error = null;
-        \set_error_handler(function ($_, $errstr) use (&$error) {
+        \set_error_handler(function ($_, $errstr) use (&$error): bool {
             $error = $errstr;
+            return true;
         });
 
         if ($this->writeChunkSize === -1) {

--- a/src/WritableResourceStream.php
+++ b/src/WritableResourceStream.php
@@ -8,24 +8,28 @@ use React\EventLoop\LoopInterface;
 
 final class WritableResourceStream extends EventEmitter implements WritableStreamInterface
 {
+    /** @var resource */
     private $stream;
 
     /** @var LoopInterface */
     private $loop;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $softLimit;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $writeChunkSize;
 
+    /** @var bool */
     private $listening = false;
+
+    /** @var bool */
     private $writable = true;
+
+    /** @var bool */
     private $closed = false;
+
+    /** @var string */
     private $data = '';
 
     /**
@@ -119,10 +123,10 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
     }
 
     /** @internal */
-    public function handleWrite()
+    public function handleWrite(): void
     {
         $error = null;
-        \set_error_handler(function ($_, $errstr) use (&$error): bool {
+        \set_error_handler(function (int $_, string $errstr) use (&$error): bool {
             $error = $errstr;
             return true;
         });
@@ -130,6 +134,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         if ($this->writeChunkSize === -1) {
             $sent = \fwrite($this->stream, $this->data);
         } else {
+            \assert($this->writeChunkSize >= -1);
             $sent = \fwrite($this->stream, $this->data, $this->writeChunkSize);
         }
 
@@ -151,7 +156,7 @@ final class WritableResourceStream extends EventEmitter implements WritableStrea
         }
 
         $exceeded = isset($this->data[$this->softLimit - 1]);
-        $this->data = (string) \substr($this->data, $sent);
+        $this->data = (string) \substr($this->data, (int) $sent);
 
         // buffer has been above limit and is now below limit
         if ($exceeded && !isset($this->data[$this->softLimit - 1])) {

--- a/src/WritableStreamInterface.php
+++ b/src/WritableStreamInterface.php
@@ -16,7 +16,7 @@ use Evenement\EventEmitterInterface;
  *     previously and is now ready to accept more data.
  *
  *     ```php
- *     $stream->on('drain', function () use ($stream) {
+ *     $stream->on('drain', function () use ($stream): void {
  *         echo 'Stream is now ready to accept more data';
  *     });
  *     ```
@@ -37,11 +37,11 @@ use Evenement\EventEmitterInterface;
  *     source stream.
  *
  *     ```php
- *     $stream->on('pipe', function (ReadableStreamInterface $source) use ($stream) {
+ *     $stream->on('pipe', function (ReadableStreamInterface $source) use ($stream): void {
  *         echo 'Now receiving piped data';
  *
  *         // explicitly close target if source emits an error
- *         $source->on('error', function () use ($stream) {
+ *         $source->on('error', function () use ($stream): void {
  *             $stream->close();
  *         });
  *     });
@@ -64,7 +64,7 @@ use Evenement\EventEmitterInterface;
  *     The event receives a single `Exception` argument for the error instance.
  *
  *     ```php
- *     $stream->on('error', function (Exception $e) {
+ *     $stream->on('error', function (Exception $e): void {
  *         echo 'Error: ' . $e->getMessage() . PHP_EOL;
  *     });
  *     ```
@@ -93,7 +93,7 @@ use Evenement\EventEmitterInterface;
  *     The `close` event will be emitted once the stream closes (terminates).
  *
  *     ```php
- *     $stream->on('close', function () {
+ *     $stream->on('close', function (): void {
  *         echo 'CLOSED';
  *     });
  *     ```
@@ -330,7 +330,7 @@ interface WritableStreamInterface extends EventEmitterInterface
      *
      * ```php
      * $stream->end();
-     * Loop::addTimer(1.0, function () use ($stream) {
+     * Loop::addTimer(1.0, function () use ($stream): void {
      *     $stream->close();
      * });
      * ```

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -13,7 +13,7 @@ use React\Stream\WritableStreamInterface;
 class CompositeStreamTest extends TestCase
 {
     /** @test */
-    public function itShouldCloseReadableIfNotWritable()
+    public function itShouldCloseReadableIfNotWritable(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -39,7 +39,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldCloseWritableIfNotReadable()
+    public function itShouldCloseWritableIfNotReadable(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -61,7 +61,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldForwardWritableCallsToWritableStream()
+    public function itShouldForwardWritableCallsToWritableStream(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -87,7 +87,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldForwardReadableCallsToReadableStream()
+    public function itShouldForwardReadableCallsToReadableStream(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -116,7 +116,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldNotForwardResumeIfStreamIsNotWritable()
+    public function itShouldNotForwardResumeIfStreamIsNotWritable(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -140,7 +140,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function endShouldDelegateToWritableWithData()
+    public function endShouldDelegateToWritableWithData(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -165,7 +165,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function closeShouldCloseBothStreams()
+    public function closeShouldCloseBothStreams(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -192,7 +192,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldForwardCloseOnlyOnce()
+    public function itShouldForwardCloseOnlyOnce(): void
     {
         $readable = new ThroughStream();
         $writable = new ThroughStream();
@@ -205,7 +205,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldForwardCloseAndRemoveAllListeners()
+    public function itShouldForwardCloseAndRemoveAllListeners(): void
     {
         $in = new ThroughStream();
 
@@ -224,7 +224,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldReceiveForwardedEvents()
+    public function itShouldReceiveForwardedEvents(): void
     {
         $readable = new ThroughStream();
         $writable = new ThroughStream();
@@ -238,7 +238,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldHandlePipingCorrectly()
+    public function itShouldHandlePipingCorrectly(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -263,7 +263,7 @@ class CompositeStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldForwardPipeCallsToReadableStream()
+    public function itShouldForwardPipeCallsToReadableStream(): void
     {
         $readable = new ThroughStream();
 

--- a/tests/CompositeStreamTest.php
+++ b/tests/CompositeStreamTest.php
@@ -23,12 +23,14 @@ class CompositeStreamTest extends TestCase
         $readable
             ->expects($this->once())
             ->method('close');
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
             ->expects($this->once())
             ->method('isWritable')
             ->willReturn(false);
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
 
@@ -44,11 +46,13 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('isReadable')
             ->willReturn(false);
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
             ->expects($this->once())
             ->method('close');
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
 
@@ -64,6 +68,7 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('isReadable')
             ->willReturn(true);
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
@@ -74,6 +79,7 @@ class CompositeStreamTest extends TestCase
             ->expects($this->exactly(2))
             ->method('isWritable')
             ->willReturn(true);
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
         $composite->write('foo');
@@ -94,12 +100,14 @@ class CompositeStreamTest extends TestCase
         $readable
             ->expects($this->once())
             ->method('resume');
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
             ->expects($this->any())
             ->method('isWritable')
             ->willReturn(true);
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
         $composite->isReadable();
@@ -118,12 +126,14 @@ class CompositeStreamTest extends TestCase
         $readable
             ->expects($this->never())
             ->method('resume');
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
             ->expects($this->exactly(2))
             ->method('isWritable')
             ->willReturnOnConsecutiveCalls(true, false);
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
         $composite->resume();
@@ -137,6 +147,7 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('isReadable')
             ->willReturn(true);
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
@@ -147,6 +158,7 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('end')
             ->with('foo');
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
         $composite->end('foo');
@@ -163,6 +175,7 @@ class CompositeStreamTest extends TestCase
         $readable
             ->expects($this->once())
             ->method('close');
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
@@ -172,6 +185,7 @@ class CompositeStreamTest extends TestCase
         $writable
             ->expects($this->once())
             ->method('close');
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
         $composite->close();
@@ -231,6 +245,7 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('isReadable')
             ->willReturn(true);
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable->expects($this->any())->method('isWritable')->willReturn(True);
@@ -238,6 +253,7 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('write')
             ->with('foo');
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
 
@@ -253,6 +269,7 @@ class CompositeStreamTest extends TestCase
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable->expects($this->any())->method('isWritable')->willReturn(True);
+        assert($writable instanceof WritableStreamInterface);
 
         $composite = new CompositeStream($readable, $writable);
 
@@ -262,6 +279,7 @@ class CompositeStreamTest extends TestCase
             ->expects($this->once())
             ->method('write')
             ->with('foo');
+        assert($output instanceof WritableStreamInterface);
 
         $composite->pipe($output);
         $readable->emit('data', ['foo']);

--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -37,7 +37,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testBufferReadsLargeChunks($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -73,7 +73,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testWriteLargeChunk($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -113,7 +113,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testDoesNotEmitDataIfNothingHasBeenWritten($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -141,7 +141,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testDoesNotWriteDataIfRemoteSideFromPairHasBeenClosed($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -171,7 +171,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testDoesNotWriteDataIfServerSideHasBeenClosed($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -204,7 +204,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testDoesNotWriteDataIfClientSideHasBeenClosed($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -237,7 +237,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testReadsSingleChunkFromProcessPipe($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -256,7 +256,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testReadsMultipleChunksFromProcessPipe($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -282,7 +282,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testReadsLongChunksFromProcessPipe($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -308,7 +308,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testReadsNothingFromProcessPipeWithNoOutput($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $loop = $loopFactory();
@@ -328,7 +328,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     public function testEmptyReadShouldntFcloseStream($condition, $loopFactory)
     {
         if (true !== $condition()) {
-            return $this->markTestSkipped('Loop implementation not available');
+            $this->markTestSkipped('Loop implementation not available');
         }
 
         $server = stream_socket_server('tcp://127.0.0.1:0');

--- a/tests/DuplexResourceStreamIntegrationTest.php
+++ b/tests/DuplexResourceStreamIntegrationTest.php
@@ -11,7 +11,7 @@ use function Clue\StreamFilter\append as filter_append;
 
 class DuplexResourceStreamIntegrationTest extends TestCase
 {
-    public function loopProvider()
+    public function loopProvider(): \Generator
     {
         yield [
             function() {
@@ -34,7 +34,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testBufferReadsLargeChunks($condition, $loopFactory)
+    public function testBufferReadsLargeChunks(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -42,7 +42,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        assert(is_array($pair));
+        [$sockA, $sockB] = $pair;
 
         $bufferSize = 4096;
         $streamA = new DuplexResourceStream($sockA, $loop, $bufferSize);
@@ -70,7 +72,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testWriteLargeChunk($condition, $loopFactory)
+    public function testWriteLargeChunk(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -78,7 +80,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        assert(is_array($pair));
+        [$sockA, $sockB] = $pair;
 
         $streamA = new DuplexResourceStream($sockA, $loop);
         $streamB = new DuplexResourceStream($sockB, $loop);
@@ -110,7 +114,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testDoesNotEmitDataIfNothingHasBeenWritten($condition, $loopFactory)
+    public function testDoesNotEmitDataIfNothingHasBeenWritten(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -118,7 +122,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        assert(is_array($pair));
+        [$sockA, $sockB] = $pair;
 
         $streamA = new DuplexResourceStream($sockA, $loop);
         $streamB = new DuplexResourceStream($sockB, $loop);
@@ -138,7 +144,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testDoesNotWriteDataIfRemoteSideFromPairHasBeenClosed($condition, $loopFactory)
+    public function testDoesNotWriteDataIfRemoteSideFromPairHasBeenClosed(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -146,7 +152,9 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        list($sockA, $sockB) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        assert(is_array($pair));
+        [$sockA, $sockB] = $pair;
 
         $streamA = new DuplexResourceStream($sockA, $loop);
         $streamB = new DuplexResourceStream($sockB, $loop);
@@ -168,7 +176,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testDoesNotWriteDataIfServerSideHasBeenClosed($condition, $loopFactory)
+    public function testDoesNotWriteDataIfServerSideHasBeenClosed(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -177,9 +185,13 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $loop = $loopFactory();
 
         $server = stream_socket_server('tcp://127.0.0.1:0');
+        assert(is_resource($server));
 
-        $client = stream_socket_client(stream_socket_get_name($server, false));
+        $client = stream_socket_client((string) stream_socket_get_name($server, false));
+        assert(is_resource($client));
+
         $peer = stream_socket_accept($server);
+        assert(is_resource($peer));
 
         $streamA = new DuplexResourceStream($client, $loop);
         $streamB = new DuplexResourceStream($peer, $loop);
@@ -201,7 +213,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testDoesNotWriteDataIfClientSideHasBeenClosed($condition, $loopFactory)
+    public function testDoesNotWriteDataIfClientSideHasBeenClosed(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -210,9 +222,13 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         $loop = $loopFactory();
 
         $server = stream_socket_server('tcp://127.0.0.1:0');
+        assert(is_resource($server));
 
-        $client = stream_socket_client(stream_socket_get_name($server, false));
+        $client = stream_socket_client((string) stream_socket_get_name($server, false));
+        assert(is_resource($client));
+
         $peer = stream_socket_accept($server);
+        assert(is_resource($peer));
 
         $streamA = new DuplexResourceStream($peer, $loop);
         $streamB = new DuplexResourceStream($client, $loop);
@@ -234,7 +250,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testReadsSingleChunkFromProcessPipe($condition, $loopFactory)
+    public function testReadsSingleChunkFromProcessPipe(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -242,7 +258,10 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('echo test', 'r'), $loop);
+        $fh = popen('echo test', 'r');
+        assert(is_resource($fh));
+
+        $stream = new ReadableResourceStream($fh, $loop);
         $stream->on('data', $this->expectCallableOnceWith("test\n"));
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
@@ -253,7 +272,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testReadsMultipleChunksFromProcessPipe($condition, $loopFactory)
+    public function testReadsMultipleChunksFromProcessPipe(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -261,7 +280,10 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('echo a;sleep 0.1;echo b;sleep 0.1;echo c', 'r'), $loop);
+        $fh = popen('echo a;sleep 0.1;echo b;sleep 0.1;echo c', 'r');
+        assert(is_resource($fh));
+
+        $stream = new ReadableResourceStream($fh, $loop);
 
         $buffer = '';
         $stream->on('data', function ($chunk) use (&$buffer) {
@@ -279,7 +301,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testReadsLongChunksFromProcessPipe($condition, $loopFactory)
+    public function testReadsLongChunksFromProcessPipe(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -287,7 +309,10 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('dd if=/dev/zero bs=12345 count=1234 2>&-', 'r'), $loop);
+        $fh = popen('dd if=/dev/zero bs=12345 count=1234 2>&-', 'r');
+        assert(is_resource($fh));
+
+        $stream = new ReadableResourceStream($fh, $loop);
 
         $bytes = 0;
         $stream->on('data', function ($chunk) use (&$bytes) {
@@ -305,7 +330,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
     /**
      * @dataProvider loopProvider
      */
-    public function testReadsNothingFromProcessPipeWithNoOutput($condition, $loopFactory)
+    public function testReadsNothingFromProcessPipeWithNoOutput(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
@@ -313,7 +338,10 @@ class DuplexResourceStreamIntegrationTest extends TestCase
 
         $loop = $loopFactory();
 
-        $stream = new ReadableResourceStream(popen('true', 'r'), $loop);
+        $fh = popen('true', 'r');
+        assert(is_resource($fh));
+
+        $stream = new ReadableResourceStream($fh, $loop);
         $stream->on('data', $this->expectCallableNever());
         $stream->on('end', $this->expectCallableOnce());
         $stream->on('error', $this->expectCallableNever());
@@ -325,16 +353,20 @@ class DuplexResourceStreamIntegrationTest extends TestCase
      * @covers React\Stream\ReadableResourceStream::handleData
      * @dataProvider loopProvider
      */
-    public function testEmptyReadShouldntFcloseStream($condition, $loopFactory)
+    public function testEmptyReadShouldntFcloseStream(callable $condition, callable $loopFactory): void
     {
         if (true !== $condition()) {
             $this->markTestSkipped('Loop implementation not available');
         }
 
         $server = stream_socket_server('tcp://127.0.0.1:0');
+        assert(is_resource($server));
 
-        $client = stream_socket_client(stream_socket_get_name($server, false));
+        $client = stream_socket_client((string) stream_socket_get_name($server, false));
+        assert(is_resource($client));
+
         $stream = stream_socket_accept($server);
+        assert(is_resource($stream));
 
 
         // add a filter which returns an error when encountering an 'a' when reading
@@ -358,7 +390,7 @@ class DuplexResourceStreamIntegrationTest extends TestCase
         fclose($server);
     }
 
-    private function loopTick(LoopInterface $loop)
+    private function loopTick(LoopInterface $loop): void
     {
         $loop->addTimer(0, function () use ($loop) {
             $loop->stop();

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -59,7 +59,7 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $this->expectException(\InvalidArgumentException::class);
-        new DuplexResourceStream('breakme', $loop);
+        new DuplexResourceStream('breakme', $loop); // @phpstan-ignore-line
     }
 
     /**
@@ -114,6 +114,7 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = $this->createMock(WritableStreamInterface::class);
+        assert($buffer instanceof WritableStreamInterface);
 
         new DuplexResourceStream($stream, $loop, null, $buffer);
     }
@@ -131,6 +132,7 @@ class DuplexResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $buffer = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
+        assert($buffer instanceof WritableStreamInterface);
 
         $this->expectException(\RuntimeException::class);
         new DuplexResourceStream($stream, $loop, null, $buffer);
@@ -157,6 +159,7 @@ class DuplexResourceStreamTest extends TestCase
 
         $buffer = $this->createMock(WritableStreamInterface::class);
         $buffer->expects($this->once())->method('end')->with('foo');
+        assert($buffer instanceof WritableStreamInterface);
 
         $conn = new DuplexResourceStream($stream, $loop, null, $buffer);
         $conn->end('foo');
@@ -170,6 +173,7 @@ class DuplexResourceStreamTest extends TestCase
 
         $buffer = $this->createMock(WritableStreamInterface::class);
         $buffer->expects($this->never())->method('end');
+        assert($buffer instanceof WritableStreamInterface);
 
         $conn = new DuplexResourceStream($stream, $loop);
         $conn->close();
@@ -409,6 +413,7 @@ class DuplexResourceStreamTest extends TestCase
 
         $conn = new DuplexResourceStream($stream, $loop);
         $dest = $this->createMock(WritableStreamInterface::class);
+        assert($dest instanceof WritableStreamInterface);
 
         $this->assertSame($dest, $conn->pipe($dest));
     }

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Stream;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use React\EventLoop\LoopInterface;
 use React\Stream\DuplexResourceStream;
 use React\Stream\WritableResourceStream;
@@ -14,17 +15,20 @@ class DuplexResourceStreamTest extends TestCase
      * @covers React\Stream\DuplexResourceStream::__construct
      * @doesNotPerformAssertions
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         new DuplexResourceStream($stream, $loop);
     }
 
-    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    public function testConstructWithoutLoopAssignsLoopAutomatically(): void
     {
         $resource = fopen('php://temp', 'r+');
+        assert(is_resource($resource));
 
         $stream = new DuplexResourceStream($resource);
 
@@ -39,11 +43,12 @@ class DuplexResourceStreamTest extends TestCase
      * @covers React\Stream\DuplexResourceStream::__construct
      * @doesNotPerformAssertions
      */
-    public function testConstructorWithExcessiveMode()
+    public function testConstructorWithExcessiveMode(): void
     {
         // excessive flags are ignored for temp streams, so we have to use a file stream
-        $name = tempnam(sys_get_temp_dir(), 'test');
-        $stream = @fopen($name, 'r+eANYTHING');
+        $name = (string) tempnam(sys_get_temp_dir(), 'test');
+        $stream = fopen($name, 'r+eANYTHING');
+        assert(is_resource($stream));
         unlink($name);
 
         $loop = $this->createLoopMock();
@@ -54,7 +59,7 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnInvalidStream()
+    public function testConstructorThrowsExceptionOnInvalidStream(): void
     {
         $loop = $this->createLoopMock();
 
@@ -65,7 +70,7 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnWriteOnlyStream()
+    public function testConstructorThrowsExceptionOnWriteOnlyStream(): void
     {
         $loop = $this->createLoopMock();
 
@@ -76,11 +81,12 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnWriteOnlyStreamWithExcessiveMode()
+    public function testConstructorThrowsExceptionOnWriteOnlyStreamWithExcessiveMode(): void
     {
         // excessive flags are ignored for temp streams, so we have to use a file stream
-        $name = tempnam(sys_get_temp_dir(), 'test');
+        $name = (string) tempnam(sys_get_temp_dir(), 'test');
         $stream = fopen($name, 'weANYTHING');
+        assert(is_resource($stream));
         unlink($name);
 
         $loop = $this->createLoopMock();
@@ -91,13 +97,15 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
+    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking(): void
     {
         if (!in_array('blocking', stream_get_wrappers())) {
             stream_wrapper_register('blocking', 'React\Tests\Stream\EnforceBlockingWrapper');
         }
 
         $stream = fopen('blocking://test', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $this->expectException(\RuntimeException::class);
@@ -108,9 +116,11 @@ class DuplexResourceStreamTest extends TestCase
      * @covers React\Stream\DuplexResourceStream::__construct
      * @doesNotPerformAssertions
      */
-    public function testConstructorAcceptsBuffer()
+    public function testConstructorAcceptsBuffer(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = $this->createMock(WritableStreamInterface::class);
@@ -122,13 +132,15 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlockingWithBufferGiven()
+    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlockingWithBufferGiven(): void
     {
         if (!in_array('blocking', stream_get_wrappers())) {
             stream_wrapper_register('blocking', 'React\Tests\Stream\EnforceBlockingWrapper');
         }
 
         $stream = fopen('blocking://test', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();
@@ -138,9 +150,11 @@ class DuplexResourceStreamTest extends TestCase
         new DuplexResourceStream($stream, $loop, null, $buffer);
     }
 
-    public function testCloseShouldEmitCloseEvent()
+    public function testCloseShouldEmitCloseEvent(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
@@ -152,9 +166,11 @@ class DuplexResourceStreamTest extends TestCase
         $this->assertFalse($conn->isReadable());
     }
 
-    public function testEndShouldEndBuffer()
+    public function testEndShouldEndBuffer(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = $this->createMock(WritableStreamInterface::class);
@@ -166,9 +182,11 @@ class DuplexResourceStreamTest extends TestCase
     }
 
 
-    public function testEndAfterCloseIsNoOp()
+    public function testEndAfterCloseIsNoOp(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = $this->createMock(WritableStreamInterface::class);
@@ -184,9 +202,11 @@ class DuplexResourceStreamTest extends TestCase
      * @covers React\Stream\DuplexResourceStream::__construct
      * @covers React\Stream\DuplexResourceStream::handleData
      */
-    public function testDataEvent()
+    public function testDataEvent(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $capturedData = null;
@@ -207,9 +227,11 @@ class DuplexResourceStreamTest extends TestCase
      * @covers React\Stream\DuplexResourceStream::__construct
      * @covers React\Stream\DuplexResourceStream::handleData
      */
-    public function testDataEventDoesEmitOneChunkMatchingBufferSize()
+    public function testDataEventDoesEmitOneChunkMatchingBufferSize(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $capturedData = null;
@@ -232,9 +254,11 @@ class DuplexResourceStreamTest extends TestCase
      * @covers React\Stream\DuplexResourceStream::__construct
      * @covers React\Stream\DuplexResourceStream::handleData
      */
-    public function testDataEventDoesEmitOneChunkUntilStreamEndsWhenBufferSizeIsInfinite()
+    public function testDataEventDoesEmitOneChunkUntilStreamEndsWhenBufferSizeIsInfinite(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $capturedData = null;
@@ -257,9 +281,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::handleData
      */
-    public function testEmptyStreamShouldNotEmitData()
+    public function testEmptyStreamShouldNotEmitData(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
@@ -271,9 +297,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::write
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createWriteableLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
@@ -288,9 +316,11 @@ class DuplexResourceStreamTest extends TestCase
      * @covers React\Stream\DuplexResourceStream::isReadable
      * @covers React\Stream\DuplexResourceStream::isWritable
      */
-    public function testEnd()
+    public function testEnd(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
@@ -304,9 +334,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::end
      */
-    public function testEndRemovesReadStreamFromLoop()
+    public function testEndRemovesReadStreamFromLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
         $loop->expects($this->once())->method('removeReadStream')->with($stream);
@@ -318,9 +350,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::pause
      */
-    public function testPauseRemovesReadStreamFromLoop()
+    public function testPauseRemovesReadStreamFromLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
         $loop->expects($this->once())->method('removeReadStream')->with($stream);
@@ -333,9 +367,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::pause
      */
-    public function testResumeDoesAddStreamToLoopOnlyOnce()
+    public function testResumeDoesAddStreamToLoopOnlyOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
 
@@ -347,9 +383,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::close
      */
-    public function testCloseRemovesReadStreamFromLoop()
+    public function testCloseRemovesReadStreamFromLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
         $loop->expects($this->once())->method('removeReadStream')->with($stream);
@@ -361,9 +399,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::close
      */
-    public function testCloseAfterPauseRemovesReadStreamFromLoopOnlyOnce()
+    public function testCloseAfterPauseRemovesReadStreamFromLoopOnlyOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
         $loop->expects($this->once())->method('removeReadStream')->with($stream);
@@ -376,9 +416,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::close
      */
-    public function testResumeAfterCloseDoesAddReadStreamToLoopOnlyOnce()
+    public function testResumeAfterCloseDoesAddReadStreamToLoopOnlyOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
 
@@ -387,10 +429,12 @@ class DuplexResourceStreamTest extends TestCase
         $conn->resume();
     }
 
-    public function testEndedStreamsShouldNotWrite()
+    public function testEndedStreamsShouldNotWrite(): void
     {
-        $file = tempnam(sys_get_temp_dir(), 'reactphptest_');
+        $file = (string) tempnam(sys_get_temp_dir(), 'reactphptest_');
         $stream = fopen($file, 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createWriteableLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
@@ -398,7 +442,9 @@ class DuplexResourceStreamTest extends TestCase
         $conn->end();
 
         $res = $conn->write("bar\n");
+
         $stream = fopen($file, 'r');
+        assert(is_resource($stream));
 
         $this->assertSame("foo\n", fgets($stream));
         $this->assertFalse($res);
@@ -406,9 +452,11 @@ class DuplexResourceStreamTest extends TestCase
         unlink($file);
     }
 
-    public function testPipeShouldReturnDestination()
+    public function testPipeShouldReturnDestination(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
@@ -418,9 +466,11 @@ class DuplexResourceStreamTest extends TestCase
         $this->assertSame($dest, $conn->pipe($dest));
     }
 
-    public function testBufferEventsShouldBubbleUp()
+    public function testBufferEventsShouldBubbleUp(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
@@ -436,9 +486,11 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::handleData
      */
-    public function testClosingStreamInDataEventShouldNotTriggerError()
+    public function testClosingStreamInDataEventShouldNotTriggerError(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new DuplexResourceStream($stream, $loop);
@@ -456,9 +508,10 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::handleData
      */
-    public function testDataFiltered()
+    public function testDataFiltered(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
 
         // add a filter which removes every 'a' when reading
         filter_append($stream, function ($chunk) {
@@ -484,9 +537,10 @@ class DuplexResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\DuplexResourceStream::handleData
      */
-    public function testDataErrorShouldEmitErrorAndClose()
+    public function testDataErrorShouldEmitErrorAndClose(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
 
         // add a filter which returns an error when encountering an 'a' when reading
         filter_append($stream, function ($chunk) {
@@ -509,7 +563,7 @@ class DuplexResourceStreamTest extends TestCase
         $conn->handleData($stream);
     }
 
-    private function createWriteableLoopMock()
+    private function createWriteableLoopMock(): LoopInterface
     {
         $loop = $this->createLoopMock();
         $loop
@@ -522,8 +576,10 @@ class DuplexResourceStreamTest extends TestCase
         return $loop;
     }
 
-    private function createLoopMock()
+    /** @return LoopInterface&MockObject */
+    private function createLoopMock(): MockObject
     {
+        /** @var MockObject&LoopInterface */
         return $this->createMock(LoopInterface::class);
     }
 }

--- a/tests/EnforceBlockingWrapper.php
+++ b/tests/EnforceBlockingWrapper.php
@@ -9,24 +9,25 @@ namespace React\Tests\Stream;
  */
 class EnforceBlockingWrapper
 {
+    /** @var resource */
     public $context;
 
-    public function stream_open($path, $mode, $options, &$opened_path)
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
     {
         return true;
     }
 
-    public function stream_cast($cast_as)
+    public function stream_cast(int $cast_as): bool
     {
         return false;
     }
 
-    public function stream_eof()
+    public function stream_eof(): bool
     {
         return false;
     }
 
-    public function stream_set_option($option, $arg1, $arg2)
+    public function stream_set_option(int $option, int $arg1, ?int $arg2): bool
     {
         if ($option === STREAM_OPTION_BLOCKING) {
             return false;

--- a/tests/FunctionalInternetTest.php
+++ b/tests/FunctionalInternetTest.php
@@ -12,10 +12,11 @@ use React\Stream\WritableResourceStream;
  */
 class FunctionalInternetTest extends TestCase
 {
-    public function testUploadKilobytePlain()
+    public function testUploadKilobytePlain(): void
     {
         $size = 1000;
         $stream = stream_socket_client('tcp://httpbin.org:80');
+        assert(is_resource($stream));
 
         $loop = Factory::create();
         $stream = new DuplexResourceStream($stream, $loop);
@@ -34,10 +35,11 @@ class FunctionalInternetTest extends TestCase
         $this->assertNotEquals('', $buffer);
     }
 
-    public function testUploadBiggerBlockPlain()
+    public function testUploadBiggerBlockPlain(): void
     {
         $size = 50 * 1000;
         $stream = stream_socket_client('tcp://httpbin.org:80');
+        assert(is_resource($stream));
 
         $loop = Factory::create();
         $stream = new DuplexResourceStream($stream, $loop);
@@ -56,10 +58,11 @@ class FunctionalInternetTest extends TestCase
         $this->assertNotEquals('', $buffer);
     }
 
-    public function testUploadKilobyteSecure()
+    public function testUploadKilobyteSecure(): void
     {
         $size = 1000;
         $stream = stream_socket_client('ssl://httpbin.org:443');
+        assert(is_resource($stream));
 
         $loop = Factory::create();
         $stream = new DuplexResourceStream($stream, $loop);
@@ -78,7 +81,7 @@ class FunctionalInternetTest extends TestCase
         $this->assertNotEquals('', $buffer);
     }
 
-    public function testUploadBiggerBlockSecure()
+    public function testUploadBiggerBlockSecure(): void
     {
         // A few dozen kilobytes should be enough to verify this works.
         // Underlying buffer sizes are platform-specific, so let's increase this
@@ -86,6 +89,7 @@ class FunctionalInternetTest extends TestCase
         $size = 136 * 1000;
 
         $stream = stream_socket_client('ssl://httpbin.org:443');
+        assert(is_resource($stream));
 
         // PHP < 7.1.4 suffers from a bug when writing big chunks of data over
         // TLS streams at once.
@@ -114,7 +118,7 @@ class FunctionalInternetTest extends TestCase
         $this->assertNotEquals('', $buffer);
     }
 
-    private function awaitStreamClose(DuplexResourceStream $stream, LoopInterface $loop, $timeout = 10.0)
+    private function awaitStreamClose(DuplexResourceStream $stream, LoopInterface $loop, float $timeout = 10.0): void
     {
         $stream->on('close', function () use ($loop) {
             $loop->stop();

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -58,7 +58,7 @@ class ReadableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $this->expectException(\InvalidArgumentException::class);
-        new ReadableResourceStream(false, $loop);
+        new ReadableResourceStream(false, $loop); // @phpstan-ignore-line
     }
 
     /**
@@ -148,7 +148,7 @@ class ReadableResourceStreamTest extends TestCase
         fwrite($stream, "foobar\n");
         rewind($stream);
 
-        $conn->handleData($stream);
+        $conn->handleData();
         $this->assertSame("foobar\n", $capturedData);
     }
 
@@ -171,7 +171,7 @@ class ReadableResourceStreamTest extends TestCase
         fwrite($stream, str_repeat("a", 100000));
         rewind($stream);
 
-        $conn->handleData($stream);
+        $conn->handleData();
 
         $this->assertTrue($conn->isReadable());
         $this->assertEquals(4321, strlen($capturedData));
@@ -197,7 +197,7 @@ class ReadableResourceStreamTest extends TestCase
         fwrite($stream, str_repeat("a", 100000));
         rewind($stream);
 
-        $conn->handleData($stream);
+        $conn->handleData();
 
         $this->assertTrue($conn->isReadable());
         $this->assertEquals(100000, strlen($capturedData));
@@ -214,7 +214,7 @@ class ReadableResourceStreamTest extends TestCase
         $conn = new ReadableResourceStream($stream, $loop);
         $conn->on('data', $this->expectCallableNever());
 
-        $conn->handleData($stream);
+        $conn->handleData();
     }
 
     public function testPipeShouldReturnDestination()
@@ -224,6 +224,7 @@ class ReadableResourceStreamTest extends TestCase
 
         $conn = new ReadableResourceStream($stream, $loop);
         $dest = $this->createMock(WritableStreamInterface::class);
+        assert($dest instanceof WritableStreamInterface);
 
         $this->assertSame($dest, $conn->pipe($dest));
     }
@@ -245,7 +246,7 @@ class ReadableResourceStreamTest extends TestCase
         fwrite($stream, "foobar\n");
         rewind($stream);
 
-        $conn->handleData($stream);
+        $conn->handleData();
     }
 
     /**
@@ -344,7 +345,7 @@ class ReadableResourceStreamTest extends TestCase
         fwrite($stream, "foobar\n");
         rewind($stream);
 
-        $conn->handleData($stream);
+        $conn->handleData();
         $this->assertSame("foobr\n", $capturedData);
     }
 
@@ -373,7 +374,7 @@ class ReadableResourceStreamTest extends TestCase
         fwrite($stream, "foobar\n");
         rewind($stream);
 
-        $conn->handleData($stream);
+        $conn->handleData();
     }
 
     /**

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Stream;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use React\EventLoop\LoopInterface;
 use React\Stream\ReadableResourceStream;
 use React\Stream\WritableStreamInterface;
@@ -13,17 +14,20 @@ class ReadableResourceStreamTest extends TestCase
      * @covers React\Stream\ReadableResourceStream::__construct
      * @doesNotPerformAssertions
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         new ReadableResourceStream($stream, $loop);
     }
 
-    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    public function testConstructWithoutLoopAssignsLoopAutomatically(): void
     {
         $resource = fopen('php://temp', 'r+');
+        assert(is_resource($resource));
 
         $stream = new ReadableResourceStream($resource);
 
@@ -38,11 +42,12 @@ class ReadableResourceStreamTest extends TestCase
      * @covers React\Stream\ReadableResourceStream::__construct
      * @doesNotPerformAssertions
      */
-    public function testConstructorWithExcessiveMode()
+    public function testConstructorWithExcessiveMode(): void
     {
         // excessive flags are ignored for temp streams, so we have to use a file stream
-        $name = tempnam(sys_get_temp_dir(), 'test');
-        $stream = @fopen($name, 'r+eANYTHING');
+        $name = (string) tempnam(sys_get_temp_dir(), 'test');
+        $stream = fopen($name, 'r+eANYTHING');
+        assert(is_resource($stream));
         unlink($name);
 
         $loop = $this->createLoopMock();
@@ -53,7 +58,7 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnInvalidStream()
+    public function testConstructorThrowsExceptionOnInvalidStream(): void
     {
         $loop = $this->createLoopMock();
 
@@ -64,7 +69,7 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnWriteOnlyStream()
+    public function testConstructorThrowsExceptionOnWriteOnlyStream(): void
     {
         $loop = $this->createLoopMock();
 
@@ -75,11 +80,12 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnWriteOnlyStreamWithExcessiveMode()
+    public function testConstructorThrowsExceptionOnWriteOnlyStreamWithExcessiveMode(): void
     {
         // excessive flags are ignored for temp streams, so we have to use a file stream
-        $name = tempnam(sys_get_temp_dir(), 'test');
+        $name = (string) tempnam(sys_get_temp_dir(), 'test');
         $stream = fopen($name, 'weANYTHING');
+        assert(is_resource($stream));
         unlink($name);
 
         $loop = $this->createLoopMock();
@@ -90,23 +96,26 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
+    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking(): void
     {
         if (!in_array('blocking', stream_get_wrappers())) {
             stream_wrapper_register('blocking', 'React\Tests\Stream\EnforceBlockingWrapper');
         }
 
         $stream = fopen('blocking://test', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $this->expectException(\RuntimeException::class);
         new ReadableResourceStream($stream, $loop);
     }
 
-
-    public function testCloseShouldEmitCloseEvent()
+    public function testCloseShouldEmitCloseEvent(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
@@ -117,9 +126,11 @@ class ReadableResourceStreamTest extends TestCase
         $this->assertFalse($conn->isReadable());
     }
 
-    public function testCloseTwiceShouldEmitCloseEventOnce()
+    public function testCloseTwiceShouldEmitCloseEventOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
@@ -133,9 +144,11 @@ class ReadableResourceStreamTest extends TestCase
      * @covers React\Stream\ReadableResourceStream::__construct
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testDataEvent()
+    public function testDataEvent(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $capturedData = null;
@@ -156,9 +169,11 @@ class ReadableResourceStreamTest extends TestCase
      * @covers React\Stream\ReadableResourceStream::__construct
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testDataEventDoesEmitOneChunkMatchingBufferSize()
+    public function testDataEventDoesEmitOneChunkMatchingBufferSize(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $capturedData = null;
@@ -181,9 +196,11 @@ class ReadableResourceStreamTest extends TestCase
      * @covers React\Stream\ReadableResourceStream::__construct
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testDataEventDoesEmitOneChunkUntilStreamEndsWhenBufferSizeIsInfinite()
+    public function testDataEventDoesEmitOneChunkUntilStreamEndsWhenBufferSizeIsInfinite(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $capturedData = null;
@@ -206,9 +223,11 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testEmptyStreamShouldNotEmitData()
+    public function testEmptyStreamShouldNotEmitData(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
@@ -217,9 +236,11 @@ class ReadableResourceStreamTest extends TestCase
         $conn->handleData();
     }
 
-    public function testPipeShouldReturnDestination()
+    public function testPipeShouldReturnDestination(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
@@ -232,9 +253,11 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testClosingStreamInDataEventShouldNotTriggerError()
+    public function testClosingStreamInDataEventShouldNotTriggerError(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
@@ -252,9 +275,11 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::pause
      */
-    public function testPauseRemovesReadStreamFromLoop()
+    public function testPauseRemovesReadStreamFromLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
         $loop->expects($this->once())->method('removeReadStream')->with($stream);
@@ -267,9 +292,11 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::pause
      */
-    public function testResumeDoesAddStreamToLoopOnlyOnce()
+    public function testResumeDoesAddStreamToLoopOnlyOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
 
@@ -281,9 +308,11 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::close
      */
-    public function testCloseRemovesReadStreamFromLoop()
+    public function testCloseRemovesReadStreamFromLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
         $loop->expects($this->once())->method('removeReadStream')->with($stream);
@@ -295,9 +324,11 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::close
      */
-    public function testCloseAfterPauseRemovesReadStreamFromLoopOnce()
+    public function testCloseAfterPauseRemovesReadStreamFromLoopOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
         $loop->expects($this->once())->method('removeReadStream')->with($stream);
@@ -310,9 +341,11 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::close
      */
-    public function testResumeAfterCloseDoesAddReadStreamToLoopOnlyOnce()
+    public function testResumeAfterCloseDoesAddReadStreamToLoopOnlyOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addReadStream')->with($stream);
 
@@ -324,9 +357,10 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testDataFiltered()
+    public function testDataFiltered(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
 
         // add a filter which removes every 'a' when reading
         filter_append($stream, function ($chunk) {
@@ -352,9 +386,10 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testDataErrorShouldEmitErrorAndClose()
+    public function testDataErrorShouldEmitErrorAndClose(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
 
         // add a filter which returns an error when encountering an 'a' when reading
         filter_append($stream, function ($chunk) {
@@ -380,9 +415,12 @@ class ReadableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\ReadableResourceStream::handleData
      */
-    public function testEmptyReadShouldntFcloseStream()
+    public function testEmptyReadShouldntFcloseStream(): void
     {
-        list($stream, $_) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, 0);
+        assert(is_array($pair));
+        [$stream, $_] = $pair;
+
         $loop = $this->createLoopMock();
 
         $conn = new ReadableResourceStream($stream, $loop);
@@ -396,8 +434,10 @@ class ReadableResourceStreamTest extends TestCase
         fclose($_);
     }
 
-    private function createLoopMock()
+    /** @return MockObject&LoopInterface */
+    private function createLoopMock(): MockObject
     {
+        /** @var MockObject&LoopInterface */
         return $this->createMock(LoopInterface::class);
     }
 }

--- a/tests/Stub/ReadableStreamStub.php
+++ b/tests/Stub/ReadableStreamStub.php
@@ -9,7 +9,10 @@ use React\Stream\Util;
 
 class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
 {
+    /** @var bool */
     public $readable = true;
+
+    /** @var bool */
     public $paused = false;
 
     public function isReadable(): bool
@@ -17,20 +20,25 @@ class ReadableStreamStub extends EventEmitter implements ReadableStreamInterface
         return true;
     }
 
-    // trigger data event
-    public function write($data)
+    /**
+     * trigger data event
+     *
+     * @param mixed $data
+     * @return void
+     */
+    public function write($data): void
     {
         $this->emit('data', [$data]);
     }
 
     // trigger error event
-    public function error($error)
+    public function error(\Exception $error): void
     {
         $this->emit('error', [$error]);
     }
 
     // trigger end event
-    public function end()
+    public function end(): void
     {
         $this->emit('end', []);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,12 @@
 
 namespace React\Tests\Stream;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    protected function expectCallableOnce()
+    protected function expectCallableOnce(): callable
     {
         $mock = $this->createCallableMock();
         $mock
@@ -16,7 +17,8 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function expectCallableOnceWith($value)
+    /** @param mixed $value */
+    protected function expectCallableOnceWith($value): callable
     {
         $callback = $this->createCallableMock();
         $callback
@@ -27,7 +29,7 @@ class TestCase extends BaseTestCase
         return $callback;
     }
 
-    protected function expectCallableNever()
+    protected function expectCallableNever(): callable
     {
         $mock = $this->createCallableMock();
         $mock
@@ -37,15 +39,19 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function createCallableMock()
+    /** @return MockObject&callable */
+    protected function createCallableMock(): MockObject
     {
         $builder = $this->getMockBuilder(\stdClass::class);
         if (method_exists($builder, 'addMethods')) {
             // PHPUnit 9+
-            return $builder->addMethods(['__invoke'])->getMock();
+            $mock = $builder->addMethods(['__invoke'])->getMock();
         } else {
             // legacy PHPUnit
-            return $builder->setMethods(['__invoke'])->getMock();
+            $mock = $builder->setMethods(['__invoke'])->getMock();
         }
+        assert($mock instanceof MockObject && is_callable($mock));
+
+        return $mock;
     }
 }

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -216,7 +216,7 @@ class ThroughStreamTest extends TestCase
     public function endTwiceShouldOnlyEmitOnce()
     {
         $through = new ThroughStream();
-        $through->on('data', $this->expectCallableOnce('first'));
+        $through->on('data', $this->expectCallableOnceWith('first'));
         $through->end('first');
         $through->end('ignored');
     }
@@ -309,6 +309,7 @@ class ThroughStreamTest extends TestCase
             ->expects($this->once())
             ->method('write')
             ->with('foo');
+        assert($output instanceof WritableStreamInterface);
 
         $through = new ThroughStream();
         $through->pipe($output);

--- a/tests/ThroughStreamTest.php
+++ b/tests/ThroughStreamTest.php
@@ -11,7 +11,7 @@ use React\Stream\WritableStreamInterface;
 class ThroughStreamTest extends TestCase
 {
     /** @test */
-    public function itShouldReturnTrueForAnyDataWrittenToIt()
+    public function itShouldReturnTrueForAnyDataWrittenToIt(): void
     {
         $through = new ThroughStream();
         $ret = $through->write('foo');
@@ -20,7 +20,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldEmitAnyDataWrittenToIt()
+    public function itShouldEmitAnyDataWrittenToIt(): void
     {
         $through = new ThroughStream();
         $through->on('data', $this->expectCallableOnceWith('foo'));
@@ -28,7 +28,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldEmitAnyDataWrittenToItPassedThruFunction()
+    public function itShouldEmitAnyDataWrittenToItPassedThruFunction(): void
     {
         $through = new ThroughStream('strtoupper');
         $through->on('data', $this->expectCallableOnceWith('FOO'));
@@ -36,7 +36,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldEmitAnyDataWrittenToItPassedThruCallback()
+    public function itShouldEmitAnyDataWrittenToItPassedThruCallback(): void
     {
         $through = new ThroughStream('strtoupper');
         $through->on('data', $this->expectCallableOnceWith('FOO'));
@@ -44,7 +44,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldEmitErrorAndCloseIfCallbackThrowsException()
+    public function itShouldEmitErrorAndCloseIfCallbackThrowsException(): void
     {
         $through = new ThroughStream(function () {
             throw new \RuntimeException();
@@ -61,7 +61,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldEmitErrorAndCloseIfCallbackThrowsExceptionOnEnd()
+    public function itShouldEmitErrorAndCloseIfCallbackThrowsExceptionOnEnd(): void
     {
         $through = new ThroughStream(function () {
             throw new \RuntimeException();
@@ -78,7 +78,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldReturnFalseForAnyDataWrittenToItWhenPaused()
+    public function itShouldReturnFalseForAnyDataWrittenToItWhenPaused(): void
     {
         $through = new ThroughStream();
         $through->pause();
@@ -88,7 +88,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldReturnFalseForAnyDataWrittenToItWhenDataEventEndsStream()
+    public function itShouldReturnFalseForAnyDataWrittenToItWhenDataEventEndsStream(): void
     {
         $through = new ThroughStream();
         $through->on('data', function () use ($through) {
@@ -100,7 +100,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldReturnFalseForAnyDataWrittenToItWhenDataEventClosesStream()
+    public function itShouldReturnFalseForAnyDataWrittenToItWhenDataEventClosesStream(): void
     {
         $through = new ThroughStream();
         $through->on('data', function () use ($through) {
@@ -112,7 +112,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldEmitDrainOnResumeAfterReturnFalseForAnyDataWrittenToItWhenPaused()
+    public function itShouldEmitDrainOnResumeAfterReturnFalseForAnyDataWrittenToItWhenPaused(): void
     {
         $through = new ThroughStream();
         $through->pause();
@@ -123,7 +123,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldNotEmitDrainOnResumeAfterClose()
+    public function itShouldNotEmitDrainOnResumeAfterClose(): void
     {
         $through = new ThroughStream();
         $through->close();
@@ -133,7 +133,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldNotEmitDrainOnResumeAfterReturnFalseForAnyDataWrittenThatCausesStreamToClose()
+    public function itShouldNotEmitDrainOnResumeAfterReturnFalseForAnyDataWrittenThatCausesStreamToClose(): void
     {
         $through = new ThroughStream();
         $through->on('data', function () use ($through) { $through->close(); });
@@ -144,7 +144,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldReturnFalseForAnyDataWrittenToItAfterPausingFromDrainEvent()
+    public function itShouldReturnFalseForAnyDataWrittenToItAfterPausingFromDrainEvent(): void
     {
         $through = new ThroughStream();
         $through->pause();
@@ -157,7 +157,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldReturnTrueForAnyDataWrittenToItWhenResumedAfterPause()
+    public function itShouldReturnTrueForAnyDataWrittenToItWhenResumedAfterPause(): void
     {
         $through = new ThroughStream();
         $through->on('drain', $this->expectCallableNever());
@@ -169,7 +169,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function pipingStuffIntoItShouldWork()
+    public function pipingStuffIntoItShouldWork(): void
     {
         $readable = new ThroughStream();
 
@@ -181,7 +181,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function endShouldEmitEndAndClose()
+    public function endShouldEmitEndAndClose(): void
     {
         $through = new ThroughStream();
         $through->on('data', $this->expectCallableNever());
@@ -191,7 +191,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function endShouldCloseTheStream()
+    public function endShouldCloseTheStream(): void
     {
         $through = new ThroughStream();
         $through->on('data', $this->expectCallableNever());
@@ -202,7 +202,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function endShouldWriteDataBeforeClosing()
+    public function endShouldWriteDataBeforeClosing(): void
     {
         $through = new ThroughStream();
         $through->on('data', $this->expectCallableOnceWith('foo'));
@@ -213,7 +213,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function endTwiceShouldOnlyEmitOnce()
+    public function endTwiceShouldOnlyEmitOnce(): void
     {
         $through = new ThroughStream();
         $through->on('data', $this->expectCallableOnceWith('first'));
@@ -222,7 +222,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function writeAfterEndShouldReturnFalse()
+    public function writeAfterEndShouldReturnFalse(): void
     {
         $through = new ThroughStream();
         $through->on('data', $this->expectCallableNever());
@@ -232,7 +232,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function writeDataWillCloseStreamShouldReturnFalse()
+    public function writeDataWillCloseStreamShouldReturnFalse(): void
     {
         $through = new ThroughStream();
         $through->on('data', [$through, 'close']);
@@ -241,7 +241,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function writeDataToPausedShouldReturnFalse()
+    public function writeDataToPausedShouldReturnFalse(): void
     {
         $through = new ThroughStream();
         $through->pause();
@@ -250,7 +250,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function writeDataToResumedShouldReturnTrue()
+    public function writeDataToResumedShouldReturnTrue(): void
     {
         $through = new ThroughStream();
         $through->pause();
@@ -260,21 +260,21 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function itShouldBeReadableByDefault()
+    public function itShouldBeReadableByDefault(): void
     {
         $through = new ThroughStream();
         $this->assertTrue($through->isReadable());
     }
 
     /** @test */
-    public function itShouldBeWritableByDefault()
+    public function itShouldBeWritableByDefault(): void
     {
         $through = new ThroughStream();
         $this->assertTrue($through->isWritable());
     }
 
     /** @test */
-    public function closeShouldCloseOnce()
+    public function closeShouldCloseOnce(): void
     {
         $through = new ThroughStream();
 
@@ -287,7 +287,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function doubleCloseShouldCloseOnce()
+    public function doubleCloseShouldCloseOnce(): void
     {
         $through = new ThroughStream();
 
@@ -301,7 +301,7 @@ class ThroughStreamTest extends TestCase
     }
 
     /** @test */
-    public function pipeShouldPipeCorrectly()
+    public function pipeShouldPipeCorrectly(): void
     {
         $output = $this->createMock(WritableStreamInterface::class);
         $output->expects($this->any())->method('isWritable')->willReturn(True);

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -15,7 +15,7 @@ use React\Stream\WritableStreamInterface;
  */
 class UtilTest extends TestCase
 {
-    public function testPipeReturnsDestinationStream()
+    public function testPipeReturnsDestinationStream(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         assert($readable instanceof ReadableStreamInterface);
@@ -28,7 +28,7 @@ class UtilTest extends TestCase
         $this->assertSame($writable, $ret);
     }
 
-    public function testPipeNonReadableSourceShouldDoNothing()
+    public function testPipeNonReadableSourceShouldDoNothing(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -49,7 +49,7 @@ class UtilTest extends TestCase
         Util::pipe($readable, $writable);
     }
 
-    public function testPipeIntoNonWritableDestinationShouldPauseSource()
+    public function testPipeIntoNonWritableDestinationShouldPauseSource(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -74,7 +74,7 @@ class UtilTest extends TestCase
         Util::pipe($readable, $writable);
     }
 
-    public function testPipeClosingDestPausesSource()
+    public function testPipeClosingDestPausesSource(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable
@@ -93,7 +93,7 @@ class UtilTest extends TestCase
         $writable->close();
     }
 
-    public function testPipeWithEnd()
+    public function testPipeWithEnd(): void
     {
         $readable = new Stub\ReadableStreamStub();
 
@@ -112,7 +112,7 @@ class UtilTest extends TestCase
         $readable->end();
     }
 
-    public function testPipeWithoutEnd()
+    public function testPipeWithoutEnd(): void
     {
         $readable = new Stub\ReadableStreamStub();
 
@@ -131,7 +131,7 @@ class UtilTest extends TestCase
         $readable->end();
     }
 
-    public function testPipeWithTooSlowWritableShouldPauseReadable()
+    public function testPipeWithTooSlowWritableShouldPauseReadable(): void
     {
         $readable = new Stub\ReadableStreamStub();
 
@@ -154,7 +154,7 @@ class UtilTest extends TestCase
         $this->assertTrue($readable->paused);
     }
 
-    public function testPipeWithTooSlowWritableShouldResumeOnDrain()
+    public function testPipeWithTooSlowWritableShouldResumeOnDrain(): void
     {
         $readable = new Stub\ReadableStreamStub();
 
@@ -184,11 +184,13 @@ class UtilTest extends TestCase
         $this->assertFalse($readable->paused);
     }
 
-    public function testPipeWithWritableResourceStream()
+    public function testPipeWithWritableResourceStream(): void
     {
         $readable = new Stub\ReadableStreamStub();
 
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createMock(LoopInterface::class);
         assert($loop instanceof LoopInterface);
         $buffer = new WritableResourceStream($stream, $loop);
@@ -203,7 +205,7 @@ class UtilTest extends TestCase
         $this->assertSame('hello, I am some random data', stream_get_contents($stream));
     }
 
-    public function testPipeSetsUpListeners()
+    public function testPipeSetsUpListeners(): void
     {
         $source = new ThroughStream();
         $dest = new ThroughStream();
@@ -219,7 +221,7 @@ class UtilTest extends TestCase
         $this->assertCount(1, $dest->listeners('drain'));
     }
 
-    public function testPipeClosingSourceRemovesListeners()
+    public function testPipeClosingSourceRemovesListeners(): void
     {
         $source = new ThroughStream();
         $dest = new ThroughStream();
@@ -233,7 +235,7 @@ class UtilTest extends TestCase
         $this->assertCount(0, $dest->listeners('drain'));
     }
 
-    public function testPipeClosingDestRemovesListeners()
+    public function testPipeClosingDestRemovesListeners(): void
     {
         $source = new ThroughStream();
         $dest = new ThroughStream();
@@ -247,7 +249,7 @@ class UtilTest extends TestCase
         $this->assertCount(0, $dest->listeners('drain'));
     }
 
-    public function testPipeDuplexIntoSelfEndsOnEnd()
+    public function testPipeDuplexIntoSelfEndsOnEnd(): void
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable->expects($this->any())->method('isReadable')->willReturn(true);
@@ -267,7 +269,7 @@ class UtilTest extends TestCase
     }
 
     /** @test */
-    public function forwardEventsShouldSetupForwards()
+    public function forwardEventsShouldSetupForwards(): void
     {
         $source = new ThroughStream();
         $target = new ThroughStream();

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -18,8 +18,10 @@ class UtilTest extends TestCase
     public function testPipeReturnsDestinationStream()
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
+        assert($writable instanceof WritableStreamInterface);
 
         $ret = Util::pipe($readable, $writable);
 
@@ -33,6 +35,7 @@ class UtilTest extends TestCase
             ->expects($this->any())
             ->method('isReadable')
             ->willReturn(false);
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
@@ -41,6 +44,7 @@ class UtilTest extends TestCase
         $writable
             ->expects($this->never())
             ->method('end');
+        assert($writable instanceof WritableStreamInterface);
 
         Util::pipe($readable, $writable);
     }
@@ -55,6 +59,7 @@ class UtilTest extends TestCase
         $readable
             ->expects($this->once())
             ->method('pause');
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable
@@ -64,6 +69,7 @@ class UtilTest extends TestCase
         $writable
             ->expects($this->never())
             ->method('end');
+        assert($writable instanceof WritableStreamInterface);
 
         Util::pipe($readable, $writable);
     }
@@ -78,6 +84,7 @@ class UtilTest extends TestCase
         $readable
             ->expects($this->once())
             ->method('pause');
+        assert($readable instanceof ReadableStreamInterface);
 
         $writable = new ThroughStream();
 
@@ -98,6 +105,7 @@ class UtilTest extends TestCase
         $writable
             ->expects($this->once())
             ->method('end');
+        assert($writable instanceof WritableStreamInterface);
 
         Util::pipe($readable, $writable);
 
@@ -116,6 +124,7 @@ class UtilTest extends TestCase
         $writable
             ->expects($this->never())
             ->method('end');
+        assert($writable instanceof WritableStreamInterface);
 
         Util::pipe($readable, $writable, ['end' => false]);
 
@@ -136,6 +145,7 @@ class UtilTest extends TestCase
             ->method('write')
             ->with('some data')
             ->will($this->returnValue(false));
+        assert($writable instanceof WritableStreamInterface);
 
         $readable->pipe($writable);
 
@@ -163,6 +173,7 @@ class UtilTest extends TestCase
                     $onDrain = $callback;
                 }
             }));
+        assert($writable instanceof WritableStreamInterface);
 
         $readable->pipe($writable);
         $readable->pause();
@@ -179,6 +190,7 @@ class UtilTest extends TestCase
 
         $stream = fopen('php://temp', 'r+');
         $loop = $this->createMock(LoopInterface::class);
+        assert($loop instanceof LoopInterface);
         $buffer = new WritableResourceStream($stream, $loop);
 
         $readable->pipe($buffer);
@@ -239,8 +251,12 @@ class UtilTest extends TestCase
     {
         $readable = $this->createMock(ReadableStreamInterface::class);
         $readable->expects($this->any())->method('isReadable')->willReturn(true);
+        assert($readable instanceof ReadableStreamInterface);
+
         $writable = $this->createMock(WritableStreamInterface::class);
         $writable->expects($this->any())->method('isWritable')->willReturn(true);
+        assert($writable instanceof WritableStreamInterface);
+
         $duplex = new CompositeStream($readable, $writable);
 
         Util::pipe($duplex, $duplex);

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -58,7 +58,7 @@ class WritableResourceStreamTest extends TestCase
         $loop = $this->createLoopMock();
 
         $this->expectException(\InvalidArgumentException::class);
-        new WritableResourceStream($stream, $loop);
+        new WritableResourceStream($stream, $loop); // @phpstan-ignore-line
     }
 
     /**
@@ -165,6 +165,7 @@ class WritableResourceStreamTest extends TestCase
             ->expects($this->any())
             ->method('addWriteStream')
             ->will($this->returnCallback(function ($stream, $listener) use (&$preventWrites) {
+                /** @var bool $preventWrites */
                 if (!$preventWrites) {
                     call_user_func($listener, $stream);
                 }

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -2,6 +2,7 @@
 
 namespace React\Tests\Stream;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use React\EventLoop\LoopInterface;
 use React\Stream\WritableResourceStream;
 use function Clue\StreamFilter\append as filter_append;
@@ -12,17 +13,20 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::__construct
      * @doesNotPerformAssertions
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         new WritableResourceStream($stream, $loop);
     }
 
-    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    public function testConstructWithoutLoopAssignsLoopAutomatically(): void
     {
         $resource = fopen('php://temp', 'r+');
+        assert(is_resource($resource));
 
         $stream = new WritableResourceStream($resource);
 
@@ -37,11 +41,12 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::__construct
      * @doesNotPerformAssertions
      */
-    public function testConstructorWithExcessiveMode()
+    public function testConstructorWithExcessiveMode(): void
     {
         // excessive flags are ignored for temp streams, so we have to use a file stream
-        $name = tempnam(sys_get_temp_dir(), 'test');
-        $stream = @fopen($name, 'w+eANYTHING');
+        $name = (string) tempnam(sys_get_temp_dir(), 'test');
+        $stream = fopen($name, 'w+eANYTHING');
+        assert(is_resource($stream));
         unlink($name);
 
         $loop = $this->createLoopMock();
@@ -52,7 +57,7 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::__construct
      */
-    public function testConstructorThrowsIfNotAValidStreamResource()
+    public function testConstructorThrowsIfNotAValidStreamResource(): void
     {
         $stream = null;
         $loop = $this->createLoopMock();
@@ -64,9 +69,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnReadOnlyStream()
+    public function testConstructorThrowsExceptionOnReadOnlyStream(): void
     {
         $stream = fopen('php://temp', 'r');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $this->expectException(\InvalidArgumentException::class);
@@ -76,11 +83,12 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionOnReadOnlyStreamWithExcessiveMode()
+    public function testConstructorThrowsExceptionOnReadOnlyStreamWithExcessiveMode(): void
     {
         // excessive flags are ignored for temp streams, so we have to use a file stream
-        $name = tempnam(sys_get_temp_dir(), 'test');
+        $name = (string) tempnam(sys_get_temp_dir(), 'test');
         $stream = fopen($name, 'reANYTHING');
+        assert(is_resource($stream));
         unlink($name);
 
         $loop = $this->createLoopMock();
@@ -91,13 +99,15 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::__construct
      */
-    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking()
+    public function testConstructorThrowsExceptionIfStreamDoesNotSupportNonBlocking(): void
     {
         if (!in_array('blocking', stream_get_wrappers())) {
             stream_wrapper_register('blocking', 'React\Tests\Stream\EnforceBlockingWrapper');
         }
 
         $stream = fopen('blocking://test', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $this->expectException(\RuntimeException::class);
@@ -108,9 +118,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testWrite()
+    public function testWrite(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createWriteableLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
@@ -124,9 +136,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::write
      */
-    public function testWriteWithDataDoesAddResourceToLoop()
+    public function testWriteWithDataDoesAddResourceToLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('addWriteStream')->with($this->equalTo($stream));
 
@@ -139,9 +153,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testEmptyWriteDoesNotAddToLoop()
+    public function testEmptyWriteDoesNotAddToLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->never())->method('addWriteStream');
 
@@ -155,9 +171,10 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testWriteReturnsFalseWhenWritableResourceStreamIsFull()
+    public function testWriteReturnsFalseWhenWritableResourceStreamIsFull(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
 
         $preventWrites = true;
         $loop = $this->createLoopMock();
@@ -182,9 +199,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::write
      */
-    public function testWriteReturnsFalseWhenWritableResourceStreamIsExactlyFull()
+    public function testWriteReturnsFalseWhenWritableResourceStreamIsExactlyFull(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop, 3);
@@ -196,9 +215,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testWriteDetectsWhenOtherSideIsClosed()
+    public function testWriteDetectsWhenOtherSideIsClosed(): void
     {
-        list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        assert(is_array($pair));
+        [$a, $b] = $pair;
 
         $loop = $this->createWriteableLoopMock();
 
@@ -214,9 +235,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testEmitsDrainAfterWriteWhichExceedsBuffer()
+    public function testEmitsDrainAfterWriteWhichExceedsBuffer(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
@@ -231,9 +254,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testWriteInDrain()
+    public function testWriteInDrain(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
@@ -255,9 +280,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testDrainAfterWrite()
+    public function testDrainAfterWrite(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop, 2);
@@ -271,9 +298,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testDrainAfterWriteWillRemoveResourceFromLoopWithoutClosing()
+    public function testDrainAfterWriteWillRemoveResourceFromLoopWithoutClosing(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('removeWriteStream')->with($stream);
 
@@ -290,9 +319,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::handleWrite
      */
-    public function testClosingDuringDrainAfterWriteWillRemoveResourceFromLoopOnceAndClose()
+    public function testClosingDuringDrainAfterWriteWillRemoveResourceFromLoopOnceAndClose(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $loop->expects($this->once())->method('removeWriteStream')->with($stream);
 
@@ -311,9 +342,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::end
      */
-    public function testEndWithoutDataClosesImmediatelyIfWritableResourceStreamIsEmpty()
+    public function testEndWithoutDataClosesImmediatelyIfWritableResourceStreamIsEmpty(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
@@ -328,9 +361,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::end
      */
-    public function testEndWithoutDataDoesNotCloseIfWritableResourceStreamIsFull()
+    public function testEndWithoutDataDoesNotCloseIfWritableResourceStreamIsFull(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
@@ -347,9 +382,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::end
      */
-    public function testEndWithDataClosesImmediatelyIfWritableResourceStreamFlushes()
+    public function testEndWithDataClosesImmediatelyIfWritableResourceStreamFlushes(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $filterBuffer = '';
         $loop = $this->createLoopMock();
 
@@ -373,9 +410,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::end
      */
-    public function testEndWithDataDoesNotCloseImmediatelyIfWritableResourceStreamIsFull()
+    public function testEndWithDataDoesNotCloseImmediatelyIfWritableResourceStreamIsFull(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
@@ -396,9 +435,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::isWritable
      * @covers React\Stream\WritableResourceStream::close
      */
-    public function testClose()
+    public function testClose(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
@@ -415,9 +456,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::close
      */
-    public function testClosingAfterWriteRemovesStreamFromLoop()
+    public function testClosingAfterWriteRemovesStreamFromLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $buffer = new WritableResourceStream($stream, $loop);
 
@@ -430,9 +473,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::close
      */
-    public function testClosingWithoutWritingDoesNotRemoveStreamFromLoop()
+    public function testClosingWithoutWritingDoesNotRemoveStreamFromLoop(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
         $buffer = new WritableResourceStream($stream, $loop);
 
@@ -444,9 +489,11 @@ class WritableResourceStreamTest extends TestCase
     /**
      * @covers React\Stream\WritableResourceStream::close
      */
-    public function testDoubleCloseWillEmitOnlyOnce()
+    public function testDoubleCloseWillEmitOnlyOnce(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $loop = $this->createLoopMock();
 
         $buffer = new WritableResourceStream($stream, $loop);
@@ -460,9 +507,11 @@ class WritableResourceStreamTest extends TestCase
      * @covers React\Stream\WritableResourceStream::write
      * @covers React\Stream\WritableResourceStream::close
      */
-    public function testWritingToClosedWritableResourceStreamShouldNotWriteToStream()
+    public function testWritingToClosedWritableResourceStreamShouldNotWriteToStream(): void
     {
         $stream = fopen('php://temp', 'r+');
+        assert(is_resource($stream));
+
         $filterBuffer = '';
         $loop = $this->createLoopMock();
 
@@ -481,13 +530,16 @@ class WritableResourceStreamTest extends TestCase
         $this->assertSame('', $filterBuffer);
     }
 
-    public function testWritingToClosedStream()
+    public function testWritingToClosedStream(): void
     {
         if ('Darwin' === PHP_OS) {
             $this->markTestSkipped('OS X issue with shutting down pair for writing');
         }
 
-        list($a, $b) = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        $pair = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+        assert(is_array($pair));
+        [$a, $b] = $pair;
+
         $loop = $this->createLoopMock();
 
         $error = null;
@@ -508,7 +560,7 @@ class WritableResourceStreamTest extends TestCase
         $this->assertEqualsIgnoringCase('Unable to write to stream: fwrite(): send of 3 bytes failed with errno=32 Broken pipe', $error->getMessage());
     }
 
-    private function createWriteableLoopMock()
+    private function createWriteableLoopMock(): LoopInterface
     {
         $loop = $this->createLoopMock();
         $loop
@@ -521,8 +573,10 @@ class WritableResourceStreamTest extends TestCase
         return $loop;
     }
 
-    private function createLoopMock()
+    /** @return MockObject&LoopInterface */
+    private function createLoopMock(): MockObject
     {
+        /** @var MockObject&LoopInterface */
         return $this->createMock(LoopInterface::class);
     }
 }


### PR DESCRIPTION
This changeset adds PHPStan on `max` level to the test environment for all supported PHP versions as discussed in #173. It runs the maximum level supported with all errors addressed without having to resort to a baseline. The changeset size seems reasonable and this does not other affect our public API, so this should be safe to apply.

Builds on top of #178, #177, #175, #174, #172 and https://github.com/reactphp/async/pull/76