### PR TITLE
chore: declare return type of `pipe()` methods by `@template`

### DIFF
--- a/src/ReadableStreamInterface.php
+++ b/src/ReadableStreamInterface.php
@@ -318,9 +318,10 @@ interface ReadableStreamInterface extends EventEmitterInterface
      * Once the pipe is set up successfully, the destination stream MUST emit
      * a `pipe` event with this source stream an event argument.
      *
-     * @param WritableStreamInterface $dest
+     * @template T of WritableStreamInterface
+     * @param T $dest
      * @param array $options
-     * @return WritableStreamInterface $dest stream as-is
+     * @return T $dest stream as-is
      */
     public function pipe(WritableStreamInterface $dest, array $options = array());
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -7,10 +7,11 @@ final class Util
     /**
      * Pipes all the data from the given $source into the $dest
      *
+     * @template T of WritableStreamInterface
      * @param ReadableStreamInterface $source
-     * @param WritableStreamInterface $dest
+     * @param T $dest
      * @param array $options
-     * @return WritableStreamInterface $dest stream as-is
+     * @return T $dest stream as-is
      * @see ReadableStreamInterface::pipe() for more details
      */
     public static function pipe(ReadableStreamInterface $source, WritableStreamInterface $dest, array $options = array())


### PR DESCRIPTION
These changes allow IDEs and PHPStan to more correctly detect the type of objects returned from the `React\Stream\Util::pipe()` and `React\Stream\ReadableStreamInterface::pipe()` methods.

After applying these changes, calling chains from `pipe()` methods will no longer result in PHPStan errors for the following code:
```php
$stream1 = new React\Stream\ThroughStream();
$stream2 = new React\Stream\ThroughStream();
$stream3 = new React\Stream\ThroughStream();
$stream4 = new React\Stream\ThroughStream();

$stream1
    ->pipe($stream2)
    ->pipe($stream3) // Call to an undefined method React\Stream\WritableStreamInterface::pipe().
    ->pipe($stream4) // Call to an undefined method React\Stream\WritableStreamInterface::pipe().
;
```

Also, the IDE (using PhpStorm as an example) will be able to correctly understand the object type returned from the `pipe()` method. The following warning will no longer appear:
```plaintext
Potentially polymorphic call. WritableResourceStream does not have members in its hierarchy
```