### PR TITLE
[1.x] Improve PHP 8.5+ support by avoiding deprecated method calls in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -47,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           coverage: xdebug
           ini-file: development
       - run: composer install

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -27,7 +27,9 @@ class DuplexResourceStreamTest extends TestCase
         $stream = new DuplexResourceStream($resource);
 
         $ref = new \ReflectionProperty($stream, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($stream);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -26,7 +26,9 @@ class ReadableResourceStreamTest extends TestCase
         $stream = new ReadableResourceStream($resource);
 
         $ref = new \ReflectionProperty($stream, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($stream);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -26,7 +26,9 @@ class WritableResourceStreamTest extends TestCase
         $stream = new WritableResourceStream($resource);
 
         $ref = new \ReflectionProperty($stream, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($stream);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -474,6 +474,10 @@ class WritableResourceStreamTest extends TestCase
      */
     public function testWritingToClosedWritableResourceStreamShouldNotWriteToStream()
     {
+        if (PHP_VERSION_ID >= 80500) {
+            $this->markTestSkipped('Since PHP 8.5 attempting to write to a closed stream will result in an error');
+        }
+
         $stream = fopen('php://temp', 'r+');
         $filterBuffer = '';
         $loop = $this->createLoopMock();


### PR DESCRIPTION
This PR adds support for PHP8.5 by running against PHP8.5 on CI and ensuring the code is compatible with PHP8.5.

Builds on #179, #184, and many others.