### PR TITLE
[3.x] Improve PHP 8.5+ support by avoiding deprecated method calls in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -42,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.5
           coverage: xdebug
           ini-file: development
       - run: composer install

--- a/tests/DuplexResourceStreamTest.php
+++ b/tests/DuplexResourceStreamTest.php
@@ -33,7 +33,9 @@ class DuplexResourceStreamTest extends TestCase
         $stream = new DuplexResourceStream($resource);
 
         $ref = new \ReflectionProperty($stream, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($stream);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/ReadableResourceStreamTest.php
+++ b/tests/ReadableResourceStreamTest.php
@@ -32,7 +32,9 @@ class ReadableResourceStreamTest extends TestCase
         $stream = new ReadableResourceStream($resource);
 
         $ref = new \ReflectionProperty($stream, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($stream);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -511,6 +511,10 @@ class WritableResourceStreamTest extends TestCase
      */
     public function testWritingToClosedWritableResourceStreamShouldNotWriteToStream(): void
     {
+        if (PHP_VERSION_ID >= 80500) {
+            $this->markTestSkipped('Since PHP 8.5 attempting to write to a closed stream will result in an error');
+        }
+
         $stream = fopen('php://temp', 'r+');
         assert(is_resource($stream));
 

--- a/tests/WritableResourceStreamTest.php
+++ b/tests/WritableResourceStreamTest.php
@@ -31,7 +31,9 @@ class WritableResourceStreamTest extends TestCase
         $stream = new WritableResourceStream($resource);
 
         $ref = new \ReflectionProperty($stream, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($stream);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by porting #185 from `1.x` to `3.x`.

Builds on #177, #181, and many others.