### PR TITLE
[3.x] Update test environment for PHP 7.2 to compatible PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "clue/stream-filter": "^1.2",
         "phpstan/phpstan": "1.12.19 || 1.4.10",
-        "phpunit/phpunit": "^9.6 || ^7.5"
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^7.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
These changes ensure we can continue to run PHPUnit on PHP 7.2 by updating PHPUnit to 8.5. This is due to recent improvements in composer as discussed in https://github.com/reactphp/event-loop/pull/284.